### PR TITLE
Fix linker flags of runtime lib (add -Wl, to -export-dynamic).

### DIFF
--- a/lib/runtime/CMakeLists.txt
+++ b/lib/runtime/CMakeLists.txt
@@ -11,5 +11,5 @@ add_library(runtime OBJECT
         ExecutionContext.cpp
         Database.cpp MetaData.cpp ArrowDirDatabase.cpp ExternalArrowDatabase.cpp MetaDataOnlyDatabase.cpp)
 target_link_libraries(runtime PUBLIC arrow_shared)
-target_link_options(runtime PUBLIC -export-dynamic)
+target_link_options(runtime PUBLIC -Wl,-export-dynamic)
 


### PR DESCRIPTION
-Wl,-export-dynamic passes the -export-dynamic flag through to the linker, which I assume was the intention. Not doing so produces a warning at link time on my machine and a binary that crashes upon every invocation before reaching the main function.