### PR TITLE
Scheduler: small task do not enqueue & debounce to put worker to sleep fix #85

### DIFF
--- a/include/lingodb/execution/Execution.h
+++ b/include/lingodb/execution/Execution.h
@@ -129,10 +129,13 @@ class QueryExecutionTask : public lingodb::scheduler::Task {
    std::function<void()> beforeDestroyFn;
    public:
    QueryExecutionTask(std::unique_ptr<QueryExecuter> queryExecutor, std::function<void()> beforeDestroyFn = nullptr) : queryExecutor(std::move(queryExecutor)), beforeDestroyFn(beforeDestroyFn) {}
-   void run() override {
+   bool reserveWork() override {
       if (workExhausted.exchange(true)) {
-         return;
+         return false;
       }
+      return true;
+   }
+   void consumeWork() override {
       queryExecutor->execute();
       if (beforeDestroyFn != nullptr) {
          beforeDestroyFn();

--- a/include/lingodb/scheduler/Scheduler.h
+++ b/include/lingodb/scheduler/Scheduler.h
@@ -11,9 +11,11 @@ class SchedulerHandle {
    ~SchedulerHandle();
 };
 
-//starts a scheduler with a given number of workers. If numWorkers is 0, the number of workers is determined by the LINGODB_PARALLELISM environment variable or std::thread::hardware_concurrency()
+//starts a scheduler with a given number of workers. 
+//If numWorkers is 0, the number of workers is determined by the LINGODB_PARALLELISM environment variable or std::thread::hardware_concurrency()
+//If initialFiberAllocs is not 0, than number of initialFiberAllocs fiber will be allocated initially.
 //if a scheduler is already running, a handle to this scheduler is returned (the number of workers is ignored)
-std::unique_ptr<SchedulerHandle> startScheduler(size_t numWorkers = 0);
+std::unique_ptr<SchedulerHandle> startScheduler(size_t initialFiberAllocs = 0, size_t numWorkers = 0);
 //waits for the scheduler to finish the current task (this is a blocking call, designed for calling from a non-worker thread)
 void awaitEntryTask(std::unique_ptr<Task> task);
 //waits for the scheduler to finish the current task (this will yield the current worker thread, only use from a worker thread)

--- a/include/lingodb/scheduler/Task.h
+++ b/include/lingodb/scheduler/Task.h
@@ -1,6 +1,7 @@
 #ifndef LINGODB_SCHEDULER_TASK_H
 #define LINGODB_SCHEDULER_TASK_H
 #include <atomic>
+#include <limits>
 namespace lingodb::scheduler {
 class Task {
    protected:
@@ -11,7 +12,9 @@ class Task {
       return !workExhausted.load();
    }
 
-   virtual void run() = 0;
+   virtual size_t workAmount() { return std::numeric_limits<size_t>::max(); }
+   virtual bool reserveWork() = 0;
+   virtual void consumeWork() = 0;
    virtual ~Task() {}
 };
 } // namespace lingodb::scheduler

--- a/src/runtime/Buffer.cpp
+++ b/src/runtime/Buffer.cpp
@@ -153,7 +153,7 @@ class BufferIteratorTask : public lingodb::scheduler::Task {
          workExhausted.store(true);
          return false;
       }
-      workerResvs.push_back(localStartIndex);
+      workerResvs[lingodb::scheduler::currentWorkerId()] = localStartIndex;
       return true;
    }
    void consumeWork() override {

--- a/src/tools/run-sql.cpp
+++ b/src/tools/run-sql.cpp
@@ -32,7 +32,12 @@ int main(int argc, char** argv) {
    unsetenv("PERF_BUILDID_DIR");
    queryExecutionConfig->timingProcessor = std::make_unique<execution::TimingPrinter>(inputFileName);
 
-   auto scheduler = scheduler::startScheduler();
+   size_t initialFiberAllocs = 0;
+   // SPEED mode allocate serveral fiber before executor run
+   if (runMode == execution::ExecutionMode::SPEED) {
+      initialFiberAllocs = 4;
+   }
+   auto scheduler = scheduler::startScheduler(initialFiberAllocs);
    auto executer = execution::QueryExecuter::createDefaultExecuter(std::move(queryExecutionConfig), *session);
    executer->fromFile(inputFileName);
    scheduler::awaitEntryTask(std::make_unique<execution::QueryExecutionTask>(std::move(executer)));


### PR DESCRIPTION
processMorsel seems take fullfill tableScan span in CT in majority cases.
![WeChat5366b35e25ad1f57e537c378898c6188](https://github.com/user-attachments/assets/30b9fba4-9eb0-436c-9794-cd8d892c8a3d)

but for tpch q2, processMorsel of the first tableScan only take about 50% the span. not sure what happend, will look into it.
![WeChateed852b9e749ad4b07c7613f64039ed1](https://github.com/user-attachments/assets/789560ee-42fc-4c77-bf85-d999ea5f100a)

another issue on q2 CT is thread 0 is not taking the first processMorsel task. i would say it maybe a system thing, which i should not take care of. processMorsel runs of the subsequent tableScan task are equally distributed to all threads.

the following code made q2 a lot faster. but not q16. i think the main thing to improve in q16 is sort, which take about 1/3 of execution time.

FIX #85 