### PR TITLE
Improve scheduler for shorter tasks + manage execution context with tasks

### DIFF
--- a/include/lingodb/compiler/frontend/SQL/Parser.h
+++ b/include/lingodb/compiler/frontend/SQL/Parser.h
@@ -232,16 +232,6 @@ struct Parser {
    bool parallelismAllowed;
    Parser(std::string sql, lingodb::runtime::Catalog& catalog, mlir::ModuleOp moduleOp);
 
-   mlir::Value getExecutionContextValue(mlir::OpBuilder& builder) {
-      mlir::func::FuncOp funcOp = moduleOp.lookupSymbol<mlir::func::FuncOp>("rt_get_execution_context");
-      if (!funcOp) {
-         mlir::OpBuilder::InsertionGuard guard(builder);
-         builder.setInsertionPointToStart(moduleOp.getBody());
-         funcOp = builder.create<mlir::func::FuncOp>(builder.getUnknownLoc(), "rt_get_execution_context", builder.getFunctionType({}, {dialect::util::RefType::get(builder.getContext(), builder.getI8Type())}), builder.getStringAttr("private"), mlir::ArrayAttr{}, mlir::ArrayAttr{});
-      }
-
-      return builder.create<mlir::func::CallOp>(builder.getUnknownLoc(), funcOp, mlir::ValueRange{}).getResult(0);
-   }
    mlir::Value createStringValue(mlir::OpBuilder& builder, std::string str) {
       return builder.create<dialect::util::CreateConstVarLen>(builder.getUnknownLoc(), dialect::util::VarLen32Type::get(builder.getContext()), builder.getStringAttr(str));
    }

--- a/include/lingodb/execution/Execution.h
+++ b/include/lingodb/execution/Execution.h
@@ -129,13 +129,13 @@ class QueryExecutionTask : public lingodb::scheduler::Task {
    std::function<void()> beforeDestroyFn;
    public:
    QueryExecutionTask(std::unique_ptr<QueryExecuter> queryExecutor, std::function<void()> beforeDestroyFn = nullptr) : queryExecutor(std::move(queryExecutor)), beforeDestroyFn(beforeDestroyFn) {}
-   bool reserveWork() override {
+   bool allocateWork() override {
       if (workExhausted.exchange(true)) {
          return false;
       }
       return true;
    }
-   void consumeWork() override {
+   void performWork() override {
       queryExecutor->execute();
       if (beforeDestroyFn != nullptr) {
          beforeDestroyFn();

--- a/include/lingodb/execution/Execution.h
+++ b/include/lingodb/execution/Execution.h
@@ -129,10 +129,13 @@ class QueryExecutionTask : public lingodb::scheduler::Task {
    std::function<void()> beforeDestroyFn;
    public:
    QueryExecutionTask(std::unique_ptr<QueryExecuter> queryExecutor, std::function<void()> beforeDestroyFn = nullptr) : queryExecutor(std::move(queryExecutor)), beforeDestroyFn(beforeDestroyFn) {}
-   void run() override {
+   bool reserveWork() override {
       if (workExhausted.exchange(true)) {
-         return;
+         return false;
       }
+      return true;
+   }
+   void consumeWork() override {
       queryExecutor->execute();
       if (beforeDestroyFn != nullptr) {
          beforeDestroyFn();

--- a/include/lingodb/runtime/Buffer.h
+++ b/include/lingodb/runtime/Buffer.h
@@ -15,7 +15,7 @@ struct BufferIterator;
 struct Buffer {
    size_t numElements;
    uint8_t* ptr;
-   static Buffer createZeroed(runtime::ExecutionContext* executionContext, size_t bytes);
+   static Buffer createZeroed(size_t bytes);
    static void iterate(bool parallel, Buffer, size_t typeSize, void (*forEachChunk)(Buffer, size_t, size_t, void*), void* contextPtr);
 };
 struct BufferIterator {

--- a/include/lingodb/runtime/DataSourceIteration.h
+++ b/include/lingodb/runtime/DataSourceIteration.h
@@ -10,7 +10,7 @@ class DataSource {
    virtual size_t getColumnId(std::string member) = 0;
    virtual void iterate(bool parallel, std::vector<size_t> colIds, const std::function<void(runtime::RecordBatchInfo*)>& cb) = 0;
    virtual ~DataSource() {}
-   static DataSource* get(ExecutionContext* executionContext, runtime::VarLen32 description);
+   static DataSource* get( runtime::VarLen32 description);
    static DataSource* getFromTable(ArrowTable* arrowTable, runtime::VarLen32 mappingVal,runtime::VarLen32 columnArray);
 };
 class DataSourceIteration {

--- a/include/lingodb/runtime/ExecutionContext.h
+++ b/include/lingodb/runtime/ExecutionContext.h
@@ -45,9 +45,9 @@ class ExecutionContext {
    const std::unordered_map<uint32_t, int64_t>& getTupleCounts() const {
       return tupleCounts;
    }
-   void setResult(uint32_t id, uint8_t* ptr);
-   void clearResult(uint32_t id);
-   void setTupleCount(uint32_t id, int64_t tupleCount);
+   static void setResult(uint32_t id, uint8_t* ptr);
+   static void clearResult(uint32_t id);
+   static void setTupleCount(uint32_t id, int64_t tupleCount);
    void registerState(const State& s) {
       states.insert(s.ptr, s);
    }
@@ -57,6 +57,9 @@ class ExecutionContext {
    void reset();
    ~ExecutionContext();
 };
+
+void setCurrentExecutionContext(ExecutionContext* context);
+ExecutionContext* getCurrentExecutionContext();
 } // end namespace lingodb::runtime
 
 #endif // LINGODB_RUNTIME_EXECUTIONCONTEXT_H

--- a/include/lingodb/runtime/GrowingBuffer.h
+++ b/include/lingodb/runtime/GrowingBuffer.h
@@ -10,7 +10,7 @@ class GrowingBufferAllocator {
    public:
    virtual GrowingBuffer* create(ExecutionContext* executionContext,size_t sizeOfType, size_t initialCapacity) = 0;
    static GrowingBufferAllocator* getDefaultAllocator();
-   static GrowingBufferAllocator* getGroupAllocator(ExecutionContext* executionContext, size_t groupId);
+   static GrowingBufferAllocator* getGroupAllocator( size_t groupId);
    virtual ~GrowingBufferAllocator(){}
 };
 class GrowingBuffer {
@@ -19,11 +19,11 @@ class GrowingBuffer {
    public:
    GrowingBuffer(size_t cap, size_t typeSize) : values(cap, typeSize) {}
    uint8_t* insert();
-   static GrowingBuffer* create(GrowingBufferAllocator* allocator, ExecutionContext* executionContext, size_t sizeOfType, size_t initialCapacity);
+   static GrowingBuffer* create(GrowingBufferAllocator* allocator, size_t sizeOfType, size_t initialCapacity);
    size_t getLen() const;
    size_t getTypeSize() const;
-   runtime::Buffer sort(runtime::ExecutionContext*, bool (*compareFn)(uint8_t*, uint8_t*));
-   runtime::Buffer asContinuous(ExecutionContext* executionContext);
+   runtime::Buffer sort(bool (*compareFn)(uint8_t*, uint8_t*));
+   runtime::Buffer asContinuous();
    static void destroy(GrowingBuffer* vec);
    BufferIterator* createIterator();
    runtime::FlexibleBuffer& getValues() { return values; }

--- a/include/lingodb/runtime/HashMultiMap.h
+++ b/include/lingodb/runtime/HashMultiMap.h
@@ -26,7 +26,7 @@ class HashMultiMap {
    void resize();
    Entry* insertEntry(size_t hash);
    Value* insertValue(Entry* entry);
-   static HashMultiMap* create(runtime::ExecutionContext* executionContext,size_t entryTypeSize, size_t valueTypeSize, size_t initialCapacity);
+   static HashMultiMap* create(size_t entryTypeSize, size_t valueTypeSize, size_t initialCapacity);
    static void destroy(HashMultiMap*);
    runtime::BufferIterator* createIterator();
 };

--- a/include/lingodb/runtime/Hashtable.h
+++ b/include/lingodb/runtime/Hashtable.h
@@ -23,7 +23,7 @@ class Hashtable {
    Entry* insert(size_t hash);
    static void lock(Entry* entry,size_t subtract);
    static void unlock(Entry* entry,size_t subtract);
-   static Hashtable* create(runtime::ExecutionContext* executionContext, size_t typeSize, size_t initialCapacity);
+   static Hashtable* create( size_t typeSize, size_t initialCapacity);
    static void destroy(Hashtable*);
    void mergeEntries(bool (*isEq)(uint8_t*, uint8_t*), void (*merge)(uint8_t*, uint8_t*), Hashtable* other);
    static runtime::Hashtable* merge(ThreadLocal*, bool (*eq)(uint8_t*, uint8_t*), void (*combine)(uint8_t*, uint8_t*));

--- a/include/lingodb/runtime/Heap.h
+++ b/include/lingodb/runtime/Heap.h
@@ -26,7 +26,7 @@ class Heap {
    public:
    Heap(size_t maxElements, size_t typeSize, CmpFn cmpFn) : cmpFn(cmpFn), typeSize(typeSize), maxElements(maxElements), currElements(0), data(new uint8_t[typeSize * (maxElements + 1)]) {
    }
-   static Heap* create(ExecutionContext* executionContext, size_t maxElements, size_t typeSize, bool (*cmpFn)(unsigned char*, unsigned char*));
+   static Heap* create(size_t maxElements, size_t typeSize, bool (*cmpFn)(unsigned char*, unsigned char*));
    void insert(uint8_t* currData);
    Buffer getBuffer();
    static void destroy(Heap*);

--- a/include/lingodb/runtime/LazyJoinHashtable.h
+++ b/include/lingodb/runtime/LazyJoinHashtable.h
@@ -26,7 +26,7 @@ class HashIndexedView {
    }
 
    public:
-   static HashIndexedView* build(runtime::ExecutionContext* executionContext,GrowingBuffer* buffer);
+   static HashIndexedView* build(GrowingBuffer* buffer);
    static void destroy(HashIndexedView*);
    ~HashIndexedView();
 };

--- a/include/lingodb/runtime/PreAggregationHashtable.h
+++ b/include/lingodb/runtime/PreAggregationHashtable.h
@@ -20,7 +20,7 @@ class PreAggregationHashtableFragment {
    size_t len;
    runtime::FlexibleBuffer* outputs[numOutputs];
    PreAggregationHashtableFragment(size_t typeSize) : ht(), typeSize(typeSize), len(0), outputs() {}
-   static PreAggregationHashtableFragment* create(runtime::ExecutionContext* context, size_t typeSize);
+   static PreAggregationHashtableFragment* create(size_t typeSize);
    Entry* insert(size_t hash);
    ~PreAggregationHashtableFragment();
 };
@@ -37,7 +37,7 @@ class PreAggregationHashtable {
    }
 
    public:
-   static runtime::PreAggregationHashtable* merge(runtime::ExecutionContext* context,ThreadLocal*, bool (*eq)(uint8_t*, uint8_t*), void (*combine)(uint8_t*, uint8_t*));
+   static runtime::PreAggregationHashtable* merge(ThreadLocal*, bool (*eq)(uint8_t*, uint8_t*), void (*combine)(uint8_t*, uint8_t*));
    Entry* lookup(size_t hash);
    static void lock(Entry* entry,size_t subtract);
    static void unlock(Entry* entry,size_t subtract);

--- a/include/lingodb/runtime/RelationHelper.h
+++ b/include/lingodb/runtime/RelationHelper.h
@@ -9,11 +9,11 @@
 namespace lingodb::runtime {
 class RelationHelper {
    public:
-   static void createTable(runtime::ExecutionContext* context, runtime::VarLen32 name, runtime::VarLen32 meta);
-   static void appendTableFromResult(runtime::VarLen32 tableName, runtime::ExecutionContext* context, size_t resultId);
-   static void copyFromIntoTable(runtime::ExecutionContext* context, runtime::VarLen32 tableName, runtime::VarLen32 fileName, runtime::VarLen32 delimiter, runtime::VarLen32 escape);
-   static void setPersist(runtime::ExecutionContext* context, bool value);
-   static HashIndexAccess* getIndex(runtime::ExecutionContext* context, runtime::VarLen32 description);
+   static void createTable(runtime::VarLen32 name, runtime::VarLen32 meta);
+   static void appendTableFromResult(runtime::VarLen32 tableName, size_t resultId);
+   static void copyFromIntoTable(runtime::VarLen32 tableName, runtime::VarLen32 fileName, runtime::VarLen32 delimiter, runtime::VarLen32 escape);
+   static void setPersist(bool value);
+   static HashIndexAccess* getIndex(runtime::VarLen32 description);
 };
 } // end namespace lingodb::runtime
 

--- a/include/lingodb/runtime/SegmentTreeView.h
+++ b/include/lingodb/runtime/SegmentTreeView.h
@@ -34,7 +34,7 @@ class SegmentTreeView {
    size_t stateCntr=0;
    public:
    void lookup(uint8_t* result, size_t from, size_t to);
-   static SegmentTreeView* build(runtime::ExecutionContext* executionContext, Buffer buffer, size_t typeSize, void (*createInitialStateFn)(unsigned char*, unsigned char*), void (*combineStatesFn)(unsigned char*, unsigned char*, unsigned char*), size_t stateTypeSize);
+   static SegmentTreeView* build(Buffer buffer, size_t typeSize, void (*createInitialStateFn)(unsigned char*, unsigned char*), void (*combineStatesFn)(unsigned char*, unsigned char*, unsigned char*), size_t stateTypeSize);
    ~SegmentTreeView();
 };
 } // namespace lingodb::runtime

--- a/include/lingodb/runtime/SimpleState.h
+++ b/include/lingodb/runtime/SimpleState.h
@@ -6,7 +6,7 @@
 namespace lingodb::runtime {
 class SimpleState {
    public:
-   static uint8_t* create(runtime::ExecutionContext* executionContext, size_t sizeOfType);
+   static uint8_t* create(size_t sizeOfType);
    static uint8_t* merge(ThreadLocal* threadLocal, void (*merge)(uint8_t* dest, uint8_t* src));
 };
 } //end namespace lingodb::runtime

--- a/include/lingodb/scheduler/Scheduler.h
+++ b/include/lingodb/scheduler/Scheduler.h
@@ -11,7 +11,9 @@ class SchedulerHandle {
    ~SchedulerHandle();
 };
 
-//starts a scheduler with a given number of workers. If numWorkers is 0, the number of workers is determined by the LINGODB_PARALLELISM environment variable or std::thread::hardware_concurrency()
+//starts a scheduler with a given number of workers. 
+//If numWorkers is 0, the number of workers is determined by the LINGODB_PARALLELISM environment variable or std::thread::hardware_concurrency()
+//If initialFiberAllocs is not 0, than number of initialFiberAllocs fiber will be allocated initially.
 //if a scheduler is already running, a handle to this scheduler is returned (the number of workers is ignored)
 std::unique_ptr<SchedulerHandle> startScheduler(size_t numWorkers = 0);
 //waits for the scheduler to finish the current task (this is a blocking call, designed for calling from a non-worker thread)

--- a/include/lingodb/scheduler/Task.h
+++ b/include/lingodb/scheduler/Task.h
@@ -1,6 +1,7 @@
 #ifndef LINGODB_SCHEDULER_TASK_H
 #define LINGODB_SCHEDULER_TASK_H
 #include <atomic>
+#include <limits>
 namespace lingodb::scheduler {
 class Task {
    protected:
@@ -11,7 +12,9 @@ class Task {
       return !workExhausted.load();
    }
 
-   virtual void run() = 0;
+   virtual size_t workAmount() { return std::numeric_limits<size_t>::max(); }
+   virtual bool reserveWork() = 0;
+   virtual void consumeWork() = 0;
    virtual ~Task() {}
 };
 } // namespace lingodb::scheduler

--- a/include/lingodb/scheduler/Task.h
+++ b/include/lingodb/scheduler/Task.h
@@ -12,9 +12,8 @@ class Task {
       return !workExhausted.load();
    }
 
-   virtual size_t workAmount() { return std::numeric_limits<size_t>::max(); }
-   virtual bool reserveWork() = 0;
-   virtual void consumeWork() = 0;
+   virtual bool allocateWork() = 0;
+   virtual void performWork() = 0;
    virtual ~Task() {}
 };
 } // namespace lingodb::scheduler

--- a/include/lingodb/scheduler/Task.h
+++ b/include/lingodb/scheduler/Task.h
@@ -2,6 +2,7 @@
 #define LINGODB_SCHEDULER_TASK_H
 #include <atomic>
 #include <limits>
+
 namespace lingodb::scheduler {
 class Task {
    protected:
@@ -14,6 +15,9 @@ class Task {
 
    virtual bool allocateWork() = 0;
    virtual void performWork() = 0;
+   //e.g., to prepare environment
+   virtual void setup() {}
+   virtual void teardown() {}
    virtual ~Task() {}
 };
 } // namespace lingodb::scheduler

--- a/include/lingodb/scheduler/Tasks.h
+++ b/include/lingodb/scheduler/Tasks.h
@@ -1,0 +1,32 @@
+
+#ifndef LINGODB_SCHEDULER_TASKS_H
+#define LINGODB_SCHEDULER_TASKS_H
+#include "lingodb/runtime/ExecutionContext.h"
+namespace lingodb::scheduler {
+class TaskWithContext : public Task {
+   runtime::ExecutionContext* context;
+
+   public:
+   TaskWithContext(runtime::ExecutionContext* context) : context(context) {}
+   void setup() override {
+      runtime::setCurrentExecutionContext(context);
+   }
+   void teardown() override {
+      runtime::setCurrentExecutionContext(nullptr);
+   }
+};
+class TaskWithImplicitContext : public Task {
+   runtime::ExecutionContext* context;
+
+   public:
+   TaskWithImplicitContext() : context(runtime::getCurrentExecutionContext()) {}
+   void setup() override {
+      runtime::setCurrentExecutionContext(context);
+   }
+   void teardown() override {
+      runtime::setCurrentExecutionContext(nullptr);
+   }
+};
+} // namespace lingodb::scheduler
+
+#endif //LINGODB_SCHEDULER_TASKS_H

--- a/include/lingodb/utility/Tracer.h
+++ b/include/lingodb/utility/Tracer.h
@@ -57,7 +57,19 @@ class Tracer {
       public:
       explicit TraceRecordList(unsigned threadId, std::string threadName) : threadId(threadId), threadName(threadName) {}
       ~TraceRecordList();
-
+      void preallocate() {
+         if (currentPos == Chunk::size) {
+            auto* nextChunk = new Chunk();
+            nextChunk->next = nullptr;
+            if (last) {
+               last->next = nextChunk;
+            } else {
+               first = nextChunk;
+            }
+            last = nextChunk;
+            currentPos = 0;
+         }
+      }
       TraceRecord* createRecord() {
          if (currentPos == Chunk::size) {
             auto* nextChunk = new Chunk();
@@ -85,10 +97,10 @@ class Tracer {
    void dumpInternal();
 
    static unsigned registerEvent(Event* event);
-   static void ensureThreadLocalTraceRecordList();
    static void recordTrace(unsigned eventId, std::chrono::steady_clock::time_point begin, std::chrono::steady_clock::time_point end, uint64_t metaData);
 
    public:
+   static void ensureThreadLocalTraceRecordList();
    Tracer() {}
    ~Tracer() {}
 

--- a/src/runtime/DataSourceIteration.cpp
+++ b/src/runtime/DataSourceIteration.cpp
@@ -62,10 +62,8 @@ class ScanBatchesTask : public lingodb::scheduler::Task {
          workerResvs.push_back(0);
       }
    }
-   size_t workAmount() override {
-      return batches.size();
-   }
-   bool reserveWork() override {
+
+   bool allocateWork() override {
       size_t localStartIndex = startIndex.fetch_add(1);
       if (localStartIndex >= batches.size()) {
          workExhausted.store(true);
@@ -74,7 +72,7 @@ class ScanBatchesTask : public lingodb::scheduler::Task {
       workerResvs[lingodb::scheduler::currentWorkerId()] = localStartIndex;
       return true;
    }
-   void consumeWork() override {
+   void performWork() override {
       auto& batch = batches[workerResvs[lingodb::scheduler::currentWorkerId()]];
       auto* batchInfo = batchInfos[lingodb::scheduler::currentWorkerId()];
       utility::Tracer::Trace trace(processMorsel);

--- a/src/runtime/DataSourceIteration.cpp
+++ b/src/runtime/DataSourceIteration.cpp
@@ -1,4 +1,6 @@
 #include "lingodb/runtime/DataSourceIteration.h"
+#include "lingodb/scheduler/Tasks.h"
+
 #include "json.h"
 #include <iterator>
 
@@ -47,7 +49,7 @@ static void access(std::vector<size_t> colIds, lingodb::runtime::RecordBatchInfo
    }
    info->numRows = currChunk->num_rows();
 }
-class ScanBatchesTask : public lingodb::scheduler::Task {
+class ScanBatchesTask : public lingodb::scheduler::TaskWithImplicitContext {
    std::vector<std::shared_ptr<arrow::RecordBatch>>& batches;
    std::vector<size_t> colIds;
    std::function<void(lingodb::runtime::RecordBatchInfo*)> cb;
@@ -162,7 +164,8 @@ lingodb::runtime::DataSourceIteration* lingodb::runtime::DataSourceIteration::in
 lingodb::runtime::DataSourceIteration::DataSourceIteration(DataSource* dataSource, const std::vector<size_t>& colIds) : dataSource(dataSource), colIds(colIds) {
 }
 
-lingodb::runtime::DataSource* lingodb::runtime::DataSource::get(lingodb::runtime::ExecutionContext* executionContext, lingodb::runtime::VarLen32 description) {
+lingodb::runtime::DataSource* lingodb::runtime::DataSource::get(lingodb::runtime::VarLen32 description) {
+   lingodb::runtime::ExecutionContext* executionContext =lingodb::runtime::getCurrentExecutionContext();
    nlohmann::json descr = nlohmann::json::parse(description.str());
    std::string tableName = descr["table"];
    auto& session = executionContext->getSession();

--- a/src/runtime/ExecutionContext.cpp
+++ b/src/runtime/ExecutionContext.cpp
@@ -1,16 +1,19 @@
 #include "lingodb/runtime/ExecutionContext.h"
-#include <iostream>
 
 void lingodb::runtime::ExecutionContext::setResult(uint32_t id, uint8_t* ptr) {
-   states.erase(ptr);
-   results[id] = ptr;
+   auto* context = getCurrentExecutionContext();
+   assert(context);
+   context->states.erase(ptr);
+   context->results[id] = ptr;
 }
-void lingodb::runtime::ExecutionContext::clearResult(uint32_t id){
-   results.erase(id);
+void lingodb::runtime::ExecutionContext::clearResult(uint32_t id) {
+   auto* context = getCurrentExecutionContext();
+   context->results.erase(id);
 }
 
 void lingodb::runtime::ExecutionContext::setTupleCount(uint32_t id, int64_t tupleCount) {
-   tupleCounts[id] = tupleCount;
+   auto* context = getCurrentExecutionContext();
+   context->tupleCounts[id] = tupleCount;
 }
 void lingodb::runtime::ExecutionContext::reset() {
    states.forEach([&](void* key, State value) {
@@ -27,4 +30,15 @@ void lingodb::runtime::ExecutionContext::reset() {
 }
 lingodb::runtime::ExecutionContext::~ExecutionContext() {
    reset();
+}
+namespace {
+thread_local lingodb::runtime::ExecutionContext* currentExecutionContext = nullptr;
+} // end namespace
+void lingodb::runtime::setCurrentExecutionContext(lingodb::runtime::ExecutionContext* context) {
+   currentExecutionContext = context;
+}
+
+lingodb::runtime::ExecutionContext* lingodb::runtime::getCurrentExecutionContext() {
+   assert(currentExecutionContext);
+   return currentExecutionContext;
 }

--- a/src/runtime/HashIndex.cpp
+++ b/src/runtime/HashIndex.cpp
@@ -90,7 +90,7 @@ void HashIndex::computeHashes() {
 
       auto executer = execution::QueryExecuter::createDefaultExecuter(std::move(queryExecutionConfig), *tmpSession);
       executer->fromData(query);
-      executer->execute();
+      scheduler::awaitChildTask(std::make_unique<execution::QueryExecutionTask>(std::move(executer)));
       result = result->CombineChunks().ValueOrDie();
       hashData = result->column(0)->chunk(0);
    }

--- a/src/runtime/HashMultiMap.cpp
+++ b/src/runtime/HashMultiMap.cpp
@@ -1,6 +1,7 @@
 #include "lingodb/runtime/HashMultiMap.h"
 
-lingodb::runtime::HashMultiMap* lingodb::runtime::HashMultiMap::create(lingodb::runtime::ExecutionContext* executionContext,size_t entryTypeSize, size_t valueTypeSize, size_t initialCapacity) {
+lingodb::runtime::HashMultiMap* lingodb::runtime::HashMultiMap::create(size_t entryTypeSize, size_t valueTypeSize, size_t initialCapacity) {
+   lingodb::runtime::ExecutionContext* executionContext= runtime::getCurrentExecutionContext();
    auto* hmm= new HashMultiMap(initialCapacity, entryTypeSize, valueTypeSize);
    executionContext->registerState({hmm, [](void* ptr) { delete reinterpret_cast<lingodb::runtime::HashMultiMap*>(ptr); }});
    return hmm;

--- a/src/runtime/Hashtable.cpp
+++ b/src/runtime/Hashtable.cpp
@@ -4,7 +4,8 @@
 namespace {
 static utility::Tracer::Event mergeEvent("Hashtable", "merge");
 } // end namespace
-lingodb::runtime::Hashtable* lingodb::runtime::Hashtable::create(lingodb::runtime::ExecutionContext* executionContext, size_t typeSize, size_t initialCapacity) {
+lingodb::runtime::Hashtable* lingodb::runtime::Hashtable::create(size_t typeSize, size_t initialCapacity) {
+   lingodb::runtime::ExecutionContext* executionContext = runtime::getCurrentExecutionContext();
    auto* ht = new Hashtable(initialCapacity, typeSize);
    executionContext->registerState({ht, [](void* ptr) { delete reinterpret_cast<lingodb::runtime::Hashtable*>(ptr); }});
    return ht;
@@ -46,7 +47,7 @@ lingodb::runtime::Hashtable* lingodb::runtime::Hashtable::merge(lingodb::runtime
    utility::Tracer::Trace mergeHt(mergeEvent);
    lingodb::runtime::Hashtable* first = nullptr;
    for (auto* current : threadLocal->getThreadLocalValues<lingodb::runtime::Hashtable>()) {
-      if(!current) continue;
+      if (!current) continue;
       if (!first) {
          first = current;
       } else {
@@ -97,5 +98,4 @@ void lingodb::runtime::Hashtable::unlock(lingodb::runtime::Hashtable::Entry* ent
    uintptr_t& nextPtr = reinterpret_cast<uintptr_t&>(entry->next);
    std::atomic_ref<uintptr_t> l(nextPtr);
    l.store(nextPtr & ~0xffff000000000000);
-
 }

--- a/src/runtime/Heap.cpp
+++ b/src/runtime/Heap.cpp
@@ -39,7 +39,8 @@ void lingodb::runtime::Heap::insert(uint8_t* currData) {
       bubbleDown(1, currElements);
    }
 }
-lingodb::runtime::Heap* lingodb::runtime::Heap::create(lingodb::runtime::ExecutionContext* executionContext, size_t maxElements, size_t typeSize, bool (*cmpFn)(unsigned char*, unsigned char*)) {
+lingodb::runtime::Heap* lingodb::runtime::Heap::create(size_t maxElements, size_t typeSize, bool (*cmpFn)(unsigned char*, unsigned char*)) {
+   auto* executionContext= runtime::getCurrentExecutionContext();
    auto* heap = new Heap(maxElements, typeSize, cmpFn);
    executionContext->registerState({heap, [](void* ptr) { delete reinterpret_cast<Heap*>(ptr); }});
    return heap;

--- a/src/runtime/LazyJoinHashtable.cpp
+++ b/src/runtime/LazyJoinHashtable.cpp
@@ -8,8 +8,9 @@
 namespace {
 static utility::Tracer::Event buildEvent("HashIndexedView", "build");
 } // end namespace
-lingodb::runtime::HashIndexedView* lingodb::runtime::HashIndexedView::build(lingodb::runtime::ExecutionContext* executionContext, lingodb::runtime::GrowingBuffer* buffer) {
+lingodb::runtime::HashIndexedView* lingodb::runtime::HashIndexedView::build(lingodb::runtime::GrowingBuffer* buffer) {
    utility::Tracer::Trace trace(buildEvent);
+   auto* executionContext= runtime::getCurrentExecutionContext();
    auto& values = buffer->getValues();
    size_t htSize = std::max(nextPow2(values.getLen() * 1.25), 1ul);
    size_t htMask = htSize - 1;

--- a/src/runtime/PreAggregationHashtable.cpp
+++ b/src/runtime/PreAggregationHashtable.cpp
@@ -23,7 +23,7 @@ class FragmentOutputsTask : public lingodb::scheduler::Task {
          workerResvs.push_back(0);
       }
    }
-   bool reserveWork() override {
+   bool allocateWork() override {
       constexpr size_t numPartitions = lingodb::runtime::PreAggregationHashtableFragment::numOutputs;
       size_t localStartIndex = startIndex.fetch_add(1);
       if (localStartIndex >= numPartitions) {
@@ -33,7 +33,7 @@ class FragmentOutputsTask : public lingodb::scheduler::Task {
       workerResvs[lingodb::scheduler::currentWorkerId()] = localStartIndex;
       return true;
    }
-   void consumeWork() override {
+   void performWork() override {
       auto& batch = outputs[workerResvs[lingodb::scheduler::currentWorkerId()]];
       cb(batch);
    }

--- a/src/runtime/RelationHelper.cpp
+++ b/src/runtime/RelationHelper.cpp
@@ -8,12 +8,14 @@
 #include <arrow/csv/api.h>
 #include <arrow/io/api.h>
 namespace lingodb::runtime {
-void RelationHelper::createTable(lingodb::runtime::ExecutionContext* context, lingodb::runtime::VarLen32 name, lingodb::runtime::VarLen32 meta) {
+void RelationHelper::createTable(lingodb::runtime::VarLen32 name, lingodb::runtime::VarLen32 meta) {
+   auto *context = getCurrentExecutionContext();
    auto& session = context->getSession();
    auto catalog = session.getCatalog();
    catalog->addTable(name.str(), lingodb::runtime::TableMetaData::deserialize(meta.str()));
 }
-void RelationHelper::appendTableFromResult(lingodb::runtime::VarLen32 tableName, lingodb::runtime::ExecutionContext* context, size_t resultId) {
+void RelationHelper::appendTableFromResult(lingodb::runtime::VarLen32 tableName, size_t resultId) {
+   auto *context = getCurrentExecutionContext();
    {
       auto resultTable = context->getResultOfType<lingodb::runtime::ArrowTable>(resultId);
       if (!resultTable) {
@@ -28,7 +30,8 @@ void RelationHelper::appendTableFromResult(lingodb::runtime::VarLen32 tableName,
       }
    }
 }
-void RelationHelper::copyFromIntoTable(lingodb::runtime::ExecutionContext* context, lingodb::runtime::VarLen32 tableName, lingodb::runtime::VarLen32 fileName, lingodb::runtime::VarLen32 delimiter, lingodb::runtime::VarLen32 escape) {
+void RelationHelper::copyFromIntoTable(lingodb::runtime::VarLen32 tableName, lingodb::runtime::VarLen32 fileName, lingodb::runtime::VarLen32 delimiter, lingodb::runtime::VarLen32 escape) {
+   auto *context = getCurrentExecutionContext();
    auto& session = context->getSession();
    auto catalog = session.getCatalog();
    if (auto relation = catalog->findRelation(tableName)) {
@@ -78,12 +81,14 @@ void RelationHelper::copyFromIntoTable(lingodb::runtime::ExecutionContext* conte
       throw std::runtime_error("copy failed: no such table");
    }
 }
-void RelationHelper::setPersist(lingodb::runtime::ExecutionContext* context, bool value) {
+void RelationHelper::setPersist(bool value) {
+   auto *context = getCurrentExecutionContext();
    auto& session = context->getSession();
    auto catalog = session.getCatalog();
    catalog->setPersist(value);
 }
-HashIndexAccess* RelationHelper::getIndex(lingodb::runtime::ExecutionContext* context, lingodb::runtime::VarLen32 description) {
+HashIndexAccess* RelationHelper::getIndex(lingodb::runtime::VarLen32 description) {
+   auto* context= runtime::getCurrentExecutionContext();
    auto json = nlohmann::json::parse(description.str());
    std::string relationName = json["relation"];
    std::string index = json["index"];

--- a/src/runtime/SegmentTreeView.cpp
+++ b/src/runtime/SegmentTreeView.cpp
@@ -74,8 +74,9 @@ void SegmentTreeView::lookupRecursively(lingodb::runtime::SegmentTreeView::TreeN
       lookupRecursively(t->right, result, from, to, first);
    }
 }
-SegmentTreeView* SegmentTreeView::build(lingodb::runtime::ExecutionContext* executionContext, Buffer buffer, size_t typeSize, void (*createInitialStateFn)(unsigned char*, unsigned char*), void (*combineStatesFn)(unsigned char*, unsigned char*, unsigned char*), size_t stateTypeSize) {
+SegmentTreeView* SegmentTreeView::build(Buffer buffer, size_t typeSize, void (*createInitialStateFn)(unsigned char*, unsigned char*), void (*combineStatesFn)(unsigned char*, unsigned char*, unsigned char*), size_t stateTypeSize) {
    utility::Tracer::Trace trace(buildEvent);
+   auto* executionContext= runtime::getCurrentExecutionContext();
    std::vector<uint8_t*> entryPointers;
    auto numElements = buffer.numElements / typeSize;
    for (size_t i = 0; i < numElements; i++) {

--- a/src/runtime/SimpleState.cpp
+++ b/src/runtime/SimpleState.cpp
@@ -5,8 +5,9 @@ namespace {
 static utility::Tracer::Event createEvent("SimpleState", "create");
 static utility::Tracer::Event mergeEvent("SimpleState", "merge");
 } // end namespace
-uint8_t* lingodb::runtime::SimpleState::create(lingodb::runtime::ExecutionContext* executionContext, size_t sizeOfType) {
+uint8_t* lingodb::runtime::SimpleState::create(size_t sizeOfType) {
    utility::Tracer::Trace trace(createEvent);
+   auto* executionContext = runtime::getCurrentExecutionContext();
    uint8_t* res = (uint8_t*) malloc(sizeOfType);
    executionContext->registerState({res, [](void* ptr) { free(ptr); }});
    trace.stop();
@@ -17,7 +18,7 @@ uint8_t* lingodb::runtime::SimpleState::merge(lingodb::runtime::ThreadLocal* thr
    utility::Tracer::Trace trace(mergeEvent);
    uint8_t* first = nullptr;
    for (auto* ptr : threadLocal->getThreadLocalValues<uint8_t>()) {
-      if(!ptr) continue;
+      if (!ptr) continue;
       auto* current = ptr;
       if (!first) {
          first = current;

--- a/src/utility/Tracer.cpp
+++ b/src/utility/Tracer.cpp
@@ -74,6 +74,7 @@ void Tracer::ensureThreadLocalTraceRecordList() {
       pthread_getname_np(pthread_self(), name, 16);
       tracer->traceRecordLists.emplace_back(std::make_unique<TraceRecordList>(tracer->traceRecordLists.size(), std::string(name)));
       threadLocalTraceRecordList = tracer->traceRecordLists[threadId].get();
+      threadLocalTraceRecordList->preallocate();
    }
 }
 const std::chrono::steady_clock::time_point initial = std::chrono::steady_clock::now();

--- a/test/lit/SQL/syntax.sql
+++ b/test/lit/SQL/syntax.sql
@@ -194,7 +194,7 @@ select min(x),max(x),sum(x),count(x), count(*)  from (values (1)) t(x);
 --//CHECK: }
 select y, min(x),max(x),sum(x),count(x), count(*) from (values (1,2)) t(x,y) group by x;
 --//CHECK: module
---//CHECK: call @_ZN7lingodb7runtime14RelationHelper11createTableEPNS0_16ExecutionContextENS0_8VarLen32ES4_(%{{.*}}, %{{.*}}, %{{.*}}) : (!util.ref<i8>, !util.varlen32, !util.varlen32) -> ()
+--//CHECK: call @{{.*}}RelationHelper{{.*}}createTable{{.*}}(%{{.*}}, %{{.*}}) : (!util.varlen32, !util.varlen32) -> ()
 create table test(
                      str varchar(20),
                      float32 float(2),
@@ -212,15 +212,14 @@ create table test(
 --//CHECK: %{{.*}} = relalg.map
 --//CHECK: %{{.*}} = relalg.materialize
 --//CHECK: subop.set_result 0
---//CHECK: call @_ZN7lingodb7runtime14RelationHelper21appendTableFromResultENS0_8VarLen32EPNS0_16ExecutionContextEm(%{{.*}}, %{{.*}}, %{{.*}}) : (!util.varlen32, !util.ref<i8>, i64) -> ()
+--//CHECK: call @{{.*}}RelationHelper{{.*}}appendTableFromResult{{.*}}(%{{.*}}, %{{.*}}) : (!util.varlen32, i64) -> ()
 INSERT into test(str, float32, float64, decimal, int32, int64, bool, date32, date64) values ('str', 1.1, 1.1, 1.10, 1, 1, 1, '1966-01-02', '1996-01-02'), (null, null, null, null, null, null, null, null, null);
 --//CHECK: module
 --//CHECK: %{{.*}} = util.varlen32_create_const "test"
 --//CHECK: %{{.*}} = util.varlen32_create_const "t.csv"
 --//CHECK: %{{.*}} = util.varlen32_create_const "|"
 --//CHECK: %{{.*}} = util.varlen32_create_const "\\"
---//CHECK: %{{.*}} = call @rt_get_execution_context() : () -> !util.ref<i8>
---//CHECK: call @_ZN7lingodb7runtime14RelationHelper17copyFromIntoTableEPNS0_16ExecutionContextENS0_8VarLen32ES4_S4_S4_(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!util.ref<i8>, !util.varlen32, !util.varlen32, !util.varlen32, !util.varlen32) -> ()
+--//CHECK: call @{{.*}}RelationHelper{{.*}}copyFromIntoTable{{.*}}(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!util.varlen32, !util.varlen32, !util.varlen32, !util.varlen32) -> ()
 copy test from 't.csv' csv escape '\' delimiter '|' null '';
 --//CHECK: %{{.*}} = relalg.aggregation %{{.*}} [@constrel{{.*}}::@const0] computes : [@aggr2::@tmp_attr31({type = i32})] (%arg0: !tuples.tuplestream,%arg1: !tuples.tuple){
 --//CHECK:       %{{.*}} = relalg.projection distinct [@constrel{{.*}}::@const1] %arg0
@@ -291,5 +290,5 @@ select 1=all(select 1);
 --//CHECK: }
 --//CHECK: %{{.*}} = relalg.exists %{{.*}}
 select 1=any(select 1);
---//CHECK: call @_ZN7lingodb7runtime14RelationHelper10setPersistEPNS0_16ExecutionContextEb(%{{.*}}, %true) : (!util.ref<i8>, i1) -> ()
+--//CHECK: call @{{.*}}RelationHelper{{.*}}setPersist{{.*}}(%true) : (i1) -> ()
 set persist=1;


### PR DESCRIPTION
Based on #87 
Improves on #85 

Additionally: now tasks can also manage some context, thus we can avoid passing execution context through compiled code.
This avoids complexity, and also leads to small compilation latency improvements ~2-3%

