### PR TITLE
Fix cleanup task's prev and next in dequeueTaskLocked for scheduler

### DIFF
--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -191,16 +191,16 @@ class Scheduler {
    void dequeueTaskLocked(TaskWrapper* task) {
       if (task->prev) {
          task->prev->next = task->next;
-         task->prev = nullptr;
       } else {
          taskHead = task->next;
       }
       if (task->next) {
          task->next->prev = task->prev;
-         task->next = nullptr;
       } else {
          taskTail = task->prev;
       }
+      task->prev = nullptr;
+      task->next = nullptr;
    }
 
    TaskWrapper* getTask() {


### PR DESCRIPTION
Need `task->next = nullptr;` in dequeueTaskLocked. because:
```
            dequeueTaskLocked(toCoolDown);
            std::lock_guard<std::mutex> lock1(coolingDownMutex);
            if (coolingDownTail) {
               coolingDownTail->next = toCoolDown;
               toCoolDown->prev = coolingDownTail;
               coolingDownTail = toCoolDown;
            }
```
after dequeueTaskLocked, only toCoolDown->prev is link to coolingDown queue, but toCoolDown->next is still linking to task queue's next task. so cleanup for task's next and prev is necessary.

so i guess it is a good habit to keep following

      task->prev = nullptr;
      task->next = nullptr;
inside dequeueTaskLocked to reset dequeued element's prev and next link, so as to keep everything clean, no garbage pointer attached which can cause issue in other logic.

## why move them out of if block
if they are still inside if blocks, for `resources/sql/tpcds/67.sql`, when there are lots task enqueue, dequeue simultaneously, task queue will be corrupted.

`task->prev = nullptr;` originally was at line 194, caused `task->next->prev = task->prev;` right part to be nullptr. Thus the `task->next->prev` has wrong assignment result, which causing task queue pop more than 1 task when calling dequeueTaskLocked.