### PR TITLE
fix tpcds and tpch db gen scripts for relative target directory paths

### DIFF
--- a/tools/generate/tpcds.sh
+++ b/tools/generate/tpcds.sh
@@ -17,14 +17,14 @@ else
 fi
 ./dsdgen -FORCE -SCALE $2
 chmod +r *.dat
+popd
 mkdir -p "$1"  # Ensure the target directory exists
-for table in ./*.dat; do
+for table in $TMPDIR/tools/*.dat; do
   # sed behaves differently on macOS and linux. Currently, there is no stable, portable command that works on both.
   if [[ "$OSTYPE" == "darwin"* ]]; then
     sed -i '' 's/|$//' "$table"  # macOS
   else
     sed -i 's/|$//' "$table"     # Linux
   fi
-  mv "$table" "$1/$table"
+  mv "$table" "$1/$(basename "$table")"
 done
-popd

--- a/tools/generate/tpch.sh
+++ b/tools/generate/tpch.sh
@@ -13,14 +13,14 @@ set -x
 ./dbgen -f -s $2
 ls -la .
 chmod +r *.tbl
+popd
 mkdir -p "$1"  # Ensure the target directory exists
-for table in ./*.tbl; do
+for table in $TMPDIR/*.tbl; do
   # sed behaves differently on macOS and linux. Currently, there is no stable, portable command that works on both.
   if [[ "$OSTYPE" == "darwin"* ]]; then
     sed -i '' 's/|$//' "$table"  # macOS
   else
     sed -i 's/|$//' "$table"     # Linux
   fi
-  mv "$table" "$1/$table"
+  mv "$table" "$1/$(basename "$table")"
 done
-popd


### PR DESCRIPTION
the tpcds.sh and tpch.sh scripts now support relative target directory paths again. This bug did not occur in CI, since we only use absolute paths in CI.