### PR TITLE
add devcontainer specification

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "ghcr.io/lingo-db/lingodb-dev:latest"
+}


### PR DESCRIPTION
To enable a better "Quickstart" for users, I added a devcontainer specification file, which allows IDEs like VSCode and CLion to automatically set up the project based on our dev-docker container, also used in the workflow pipelines. This allows an easy project setup without the need to worry about dependencies/system requirements.

Disclaimer: Support for devcontainers in CLion is still pretty bumpy. However, the support in VSCode is really good and works like a charm.

I also changed our docker build workflow scripts to properly tag the current build as latest, so that the devdocker is automatically built based on the latest pushed dev-docker image.