### PR TITLE
fix workflow cache problem(s)

### DIFF
--- a/.github/workflows/workflow-macos-15-aarch64.yml
+++ b/.github/workflows/workflow-macos-15-aarch64.yml
@@ -20,7 +20,7 @@ jobs:
         id: ccache
         uses: actions/cache@v4
         with:
-          path: $HOME/.ccache
+          path: ~/.ccache
           key: ccache-${{ matrix.build_type }}-build-build-macos-15
 
       - name: Cache Homebrew packages
@@ -44,10 +44,10 @@ jobs:
 
       - name: Build
         run: |
-          mkdir -p $HOME/.ccache
+          mkdir -p ~/.ccache
           export CXX="ccache /opt/homebrew/opt/llvm/bin/clang++"
           export CC="ccache /opt/homebrew/opt/llvm/bin/clang"
-          export CCACHE_DIR="${HOME}/.ccache"
+          export CCACHE_DIR="~/.ccache"
           export CMAKE_PREFIX_PATH="/opt/homebrew/"
 
           make clean

--- a/.github/workflows/workflow-macos-15-aarch64.yml
+++ b/.github/workflows/workflow-macos-15-aarch64.yml
@@ -78,6 +78,7 @@ jobs:
         id: cache-brew
         uses: actions/cache@v3
         with:
+          fail-on-cache-miss: True
           path: |
             /opt/homebrew
             ~/Library/Caches/Homebrew
@@ -114,6 +115,7 @@ jobs:
         id: cache-brew
         uses: actions/cache@v3
         with:
+          fail-on-cache-miss: True
           path: |
             /opt/homebrew
             ~/Library/Caches/Homebrew
@@ -149,6 +151,7 @@ jobs:
         id: cache-brew
         uses: actions/cache@v3
         with:
+          fail-on-cache-miss: True
           path: |
             /opt/homebrew
             ~/Library/Caches/Homebrew


### PR DESCRIPTION
Since cache misses have been a problem in a faulty build pipeline in #116, this PR replace the dependence on the homebrew caches with explicit, required homebrew artifacts.