### PR TITLE
force linkage of all dependencies to circumvent xcode stdlib fallbacks

### DIFF
--- a/.github/workflows/workflow-macos-15-aarch64.yml
+++ b/.github/workflows/workflow-macos-15-aarch64.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Install dependencies with Homebrew
         run: |
           brew update
-          brew install ccache cmake ninja llvm@20 catch2 lit
+          brew install ccache cmake ninja llvm@20 catch2 lit bzip2 libffi libedit libxml2 brotli zlib
+          brew link --force ccache cmake ninja llvm@20 catch2 lit bzip2 libffi libedit libxml2 brotli zlib
           brew tap lingo-db/homebrew https://github.com/lingo-db/homebrew.git
           brew install lingo-db/homebrew/apache-arrow@20
-          brew link --force llvm
 
       - name: Build
         run: |


### PR DESCRIPTION
When a dependency cannot be properly resolved from homebrew, cmake may take the version from xcode. That smuggles xcode include paths into clang's include path resolution, which causes problems since xcode's headers are significantly older (llvm-16 vs. llvm-20) and have incompatibilities.