### PR TITLE
Clang format update

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,7 @@ AlignEscapedNewlines: Left
 AlignOperands:   false
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: true
+AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: true
@@ -96,8 +96,8 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 50
 PointerAlignment: Left
-ReflowComments:  false
-SortIncludes:    true
+ReflowComments:  Never
+SortIncludes:    CaseSensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: true
 SpaceAfterTemplateKeyword: true
@@ -114,9 +114,7 @@ SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        c++20
 TabWidth:        8
 UseTab:          Never
 ...
-
-

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ lint: build/lingodb-debug/.stamp
 	python3 tools/scripts/run-clang-tidy.py -p $(dir $<) -quiet -header-filter="$(shell pwd)/include/.*" -exclude-header-filter="generated|vendored" -exclude="arrow|vendored" -clang-tidy-binary=clang-tidy-20
 
 format:
-	find include \( -name '*.cpp' -o -name '*.h' \) -exec clang-format-20 -i {} +
-	find src \( -name '*.cpp' -o -name '*.h' \) -exec clang-format-20 -i {} +
-	find tools \( -name '*.cpp' -o -name '*.h' \) -exec clang-format-20 -i {} +
-	find test \( -name '*.cpp' -o -name '*.h' \) -exec clang-format-20 -i {} +
+	find include \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) -exec clang-format-20 -i {} +
+	find src \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) -exec clang-format-20 -i {} +
+	find tools \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) -exec clang-format-20 -i {} +
+	find test \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) -exec clang-format-20 -i {} +

--- a/include/lingodb/execution/baseline/utils.hpp
+++ b/include/lingodb/execution/baseline/utils.hpp
@@ -19,60 +19,65 @@ class TupleHelper {
       unsigned elemAlign = 0;
       size_t elemSize = 0;
       llvm::TypeSwitch<mlir::Type>(elem)
-            .Case<dialect::util::RefType>([&](dialect::util::RefType t) {
-               elemSize = sizeof(void *);
-               elemAlign = alignof(void *);
-            })
-            .Case<mlir::IntegerType>([&](mlir::IntegerType t) {
-               elemSize = (t.getIntOrFloatBitWidth() + 7) / 8;
-               switch (elemSize) {
-                  case 1: elemAlign = alignof(int8_t);
-                     break;
-                  case 2: elemAlign = alignof(int16_t);
-                     break;
-                  case 4: elemAlign = alignof(int32_t);
-                     break;
-                  case 8: elemAlign = alignof(int64_t);
-                     break;
-                  case 16: elemAlign = alignof(__int128);
-                     break;
-                  default:
-                     assert(false && "Unsupported integer type width for alignment calculation.");
-                     elemAlign = 1; // fallback to 1 byte alignment
-               }
-            })
-            .Case<mlir::FloatType>([&](mlir::FloatType t) {
-               elemSize = t.getIntOrFloatBitWidth() / 8;
-               switch (t.getIntOrFloatBitWidth()) {
-                  case 32:
-                     static_assert(sizeof(float) == 4);
-                     elemAlign = alignof(float);
-                     break;
-                  case 64:
-                     static_assert(sizeof(double) == 8);
-                     elemAlign = alignof(double);
-                     break;
-                  default:
-                     assert(false && "Unsupported integer type width for alignment calculation.");
-                     elemAlign = 1; // fallback to 1 byte alignment
-               }
-            })
-            .Case<mlir::TupleType>([&](mlir::TupleType tupleType) {
-               auto [size, align] = TupleHelper{tupleType}.sizeAndPadding();
-               elemSize = size;
-               elemAlign = align;
-            })
-            .Case<mlir::IndexType>([&](auto) {
-               elemSize = sizeof(uint64_t);
-               elemAlign = alignof(uint64_t);
-            })
-            .Case<dialect::util::VarLen32Type, dialect::util::BufferType>([&](auto) {
-               elemSize = sizeof(__uint128_t);
-               elemAlign = alignof(__uint128_t);
-            })
-            .Default([](mlir::Type) {
-               assert(false && "Cannot calculate size for unsupported type.");
-            });
+         .Case<dialect::util::RefType>([&](dialect::util::RefType t) {
+            elemSize = sizeof(void*);
+            elemAlign = alignof(void*);
+         })
+         .Case<mlir::IntegerType>([&](mlir::IntegerType t) {
+            elemSize = (t.getIntOrFloatBitWidth() + 7) / 8;
+            switch (elemSize) {
+               case 1:
+                  elemAlign = alignof(int8_t);
+                  break;
+               case 2:
+                  elemAlign = alignof(int16_t);
+                  break;
+               case 4:
+                  elemAlign = alignof(int32_t);
+                  break;
+               case 8:
+                  elemAlign = alignof(int64_t);
+                  break;
+               case 16:
+                  elemAlign = alignof(__int128);
+                  break;
+               default:
+                  assert(false && "Unsupported integer type width for alignment calculation.");
+                  elemAlign = 1; // fallback to 1 byte alignment
+            }
+         })
+         .Case<mlir::FloatType>([&](mlir::FloatType t) {
+            elemSize = t.getIntOrFloatBitWidth() / 8;
+            switch (t.getIntOrFloatBitWidth()) {
+               case 32:
+                  static_assert(sizeof(float) == 4);
+                  elemAlign = alignof(float);
+                  break;
+               case 64:
+                  static_assert(sizeof(double) == 8);
+                  elemAlign = alignof(double);
+                  break;
+               default:
+                  assert(false && "Unsupported integer type width for alignment calculation.");
+                  elemAlign = 1; // fallback to 1 byte alignment
+            }
+         })
+         .Case<mlir::TupleType>([&](mlir::TupleType tupleType) {
+            auto [size, align] = TupleHelper{tupleType}.sizeAndPadding();
+            elemSize = size;
+            elemAlign = align;
+         })
+         .Case<mlir::IndexType>([&](auto) {
+            elemSize = sizeof(uint64_t);
+            elemAlign = alignof(uint64_t);
+         })
+         .Case<dialect::util::VarLen32Type, dialect::util::BufferType>([&](auto) {
+            elemSize = sizeof(__uint128_t);
+            elemAlign = alignof(__uint128_t);
+         })
+         .Default([](mlir::Type) {
+            assert(false && "Cannot calculate size for unsupported type.");
+         });
       return {elemAlign, elemSize};
    }
 

--- a/include/lingodb/runtime/GrowingBuffer.h
+++ b/include/lingodb/runtime/GrowingBuffer.h
@@ -1,8 +1,8 @@
 #ifndef LINGODB_RUNTIME_GROWINGBUFFER_H
 #define LINGODB_RUNTIME_GROWINGBUFFER_H
+#include "Buffer.h"
 #include "ExecutionContext.h"
 #include "ThreadLocal.h"
-#include "lingodb/runtime/Buffer.h"
 namespace lingodb::runtime {
 
 class GrowingBuffer;

--- a/src/execution/baseline/Adaptor.hpp
+++ b/src/execution/baseline/Adaptor.hpp
@@ -5,344 +5,341 @@
 
 #include "utils.hpp"
 
+#include <llvm/ADT/TypeSwitch.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/Operation.h>
 #include <mlir/Interfaces/FunctionInterfaces.h>
-#include <llvm/ADT/TypeSwitch.h>
-#include <mlir/IR/BuiltinOps.h>
 
 #include <tpde/ValLocalIdx.hpp>
 
+#include <format>
 #include <ranges>
 #include <sstream>
-#include <format>
-
 
 namespace lingodb::execution::baseline {
-    // NOLINTBEGIN(readability-identifier-naming)
+// NOLINTBEGIN(readability-identifier-naming)
 
-    // adaptor mlir -> tpde
-    struct IRAdaptor {
-        using IRFuncRef = mlir::func::FuncOp;
-        using IRBlockRef = mlir::Block *;
-        using IRInstRef = mlir::Operation *;
-        using IRValueRef = mlir::Value;
+// adaptor mlir -> tpde
+struct IRAdaptor {
+   using IRFuncRef = mlir::func::FuncOp;
+   using IRBlockRef = mlir::Block*;
+   using IRInstRef = mlir::Operation*;
+   using IRValueRef = mlir::Value;
 
-        [[maybe_unused]] static IRFuncRef INVALID_FUNC_REF;
-        [[maybe_unused]] static constexpr IRBlockRef INVALID_BLOCK_REF = nullptr;
-        [[maybe_unused]] static IRValueRef INVALID_VALUE_REF;
+   [[maybe_unused]] static IRFuncRef INVALID_FUNC_REF;
+   [[maybe_unused]] static constexpr IRBlockRef INVALID_BLOCK_REF = nullptr;
+   [[maybe_unused]] static IRValueRef INVALID_VALUE_REF;
 
-        [[maybe_unused]] static constexpr bool TPDE_PROVIDES_HIGHEST_VAL_IDX = true;
-        [[maybe_unused]] static constexpr bool TPDE_LIVENESS_VISIT_ARGS = true;
+   [[maybe_unused]] static constexpr bool TPDE_PROVIDES_HIGHEST_VAL_IDX = true;
+   [[maybe_unused]] static constexpr bool TPDE_LIVENESS_VISIT_ARGS = true;
 
-        using IR = mlir::ModuleOp;
+   using IR = mlir::ModuleOp;
 
-        IR *module;
-        IRFuncRef cur_func = INVALID_FUNC_REF;
-        Error &error;
+   IR* module;
+   IRFuncRef cur_func = INVALID_FUNC_REF;
+   Error& error;
 
-        struct ValInfo {
-            tpde::ValLocalIdx local_idx;
-        };
+   struct ValInfo {
+      tpde::ValLocalIdx local_idx;
+   };
 
-        llvm::DenseMap<IRBlockRef, std::pair<uint32_t, uint32_t> > blockInfoMap;
-        llvm::DenseMap<IRValueRef, ValInfo> values;
+   llvm::DenseMap<IRBlockRef, std::pair<uint32_t, uint32_t>> blockInfoMap;
+   llvm::DenseMap<IRValueRef, ValInfo> values;
 
-        IRAdaptor(mlir::ModuleOp *module, Error &error) : module(module), error(error) {
-        }
+   IRAdaptor(mlir::ModuleOp* module, Error& error) : module(module), error(error) {
+   }
 
-        Error &getError() const noexcept { return error; }
+   Error& getError() const noexcept { return error; }
 
-        [[maybe_unused]] auto funcs() const noexcept {
-            return llvm::map_range(module->getOps<mlir::func::FuncOp>(), [](mlir::func::FuncOp func) {
-                return cast<IRFuncRef>(func);
-            });
-        }
+   [[maybe_unused]] auto funcs() const noexcept {
+      return llvm::map_range(module->getOps<mlir::func::FuncOp>(), [](mlir::func::FuncOp func) {
+         return cast<IRFuncRef>(func);
+      });
+   }
 
-        [[maybe_unused]] uint32_t func_count() const noexcept {
-            const auto it = funcs();
-            return std::distance(it.begin(), it.begin());
-        }
+   [[maybe_unused]] uint32_t func_count() const noexcept {
+      const auto it = funcs();
+      return std::distance(it.begin(), it.begin());
+   }
 
-        // Then, in funcs_to_compile():
-        auto funcs_to_compile() const noexcept {
-            return llvm_iter_range_to_tpde_iter(llvm::make_filter_range(funcs(), [](mlir::func::FuncOp func) {
-                return !func.isExternal() && !func.isDeclaration();
-            }));
-        }
+   // Then, in funcs_to_compile():
+   auto funcs_to_compile() const noexcept {
+      return llvm_iter_range_to_tpde_iter(llvm::make_filter_range(funcs(), [](mlir::func::FuncOp func) {
+         return !func.isExternal() && !func.isDeclaration();
+      }));
+   }
 
-        [[maybe_unused]] std::string_view func_link_name(IRFuncRef func) const noexcept {
-            return func.getSymName();
-        }
+   [[maybe_unused]] std::string_view func_link_name(IRFuncRef func) const noexcept {
+      return func.getSymName();
+   }
 
-        [[maybe_unused]] bool func_extern(IRFuncRef func) const noexcept {
-            return func.isExternal();
-        }
+   [[maybe_unused]] bool func_extern(IRFuncRef func) const noexcept {
+      return func.isExternal();
+   }
 
-        [[maybe_unused]] bool func_only_local(IRFuncRef func) const noexcept {
-            return func.isPrivate() && !func.isExternal();
-        }
+   [[maybe_unused]] bool func_only_local(IRFuncRef func) const noexcept {
+      return func.isPrivate() && !func.isExternal();
+   }
 
-        [[maybe_unused]] static bool func_has_weak_linkage(IRFuncRef) noexcept {
-            return false; // IR does not support weak linkage
-        }
+   [[maybe_unused]] static bool func_has_weak_linkage(IRFuncRef) noexcept {
+      return false; // IR does not support weak linkage
+   }
 
-        [[maybe_unused]] static bool cur_needs_unwind_info() noexcept {
-            return true;
-        }
+   [[maybe_unused]] static bool cur_needs_unwind_info() noexcept {
+      return true;
+   }
 
-        [[maybe_unused]] static bool cur_is_vararg() noexcept {
-            return false; // we do not support varargs
-        }
+   [[maybe_unused]] static bool cur_is_vararg() noexcept {
+      return false; // we do not support varargs
+   }
 
-        [[maybe_unused]] auto cur_args() noexcept {
-            assert(cur_func && cur_func != INVALID_FUNC_REF && "No current function set");
-            return cur_func.getArguments() |
-                   std::views::transform([](mlir::BlockArgument arg) {
-                       return dyn_cast<mlir::Value>(arg);
-                   });
-        }
+   [[maybe_unused]] auto cur_args() noexcept {
+      assert(cur_func && cur_func != INVALID_FUNC_REF && "No current function set");
+      return cur_func.getArguments() |
+         std::views::transform([](mlir::BlockArgument arg) {
+                return dyn_cast<mlir::Value>(arg);
+             });
+   }
 
-        [[maybe_unused]] static bool cur_arg_is_byval(uint32_t) noexcept { return false; }
-        [[maybe_unused]] static uint32_t cur_arg_byval_align(uint32_t) noexcept { return 0; }
-        [[maybe_unused]] static uint32_t cur_arg_byval_size(uint32_t) noexcept { return 0; }
-        [[maybe_unused]] static bool cur_arg_is_sret(uint32_t) noexcept { return false; }
+   [[maybe_unused]] static bool cur_arg_is_byval(uint32_t) noexcept { return false; }
+   [[maybe_unused]] static uint32_t cur_arg_byval_align(uint32_t) noexcept { return 0; }
+   [[maybe_unused]] static uint32_t cur_arg_byval_size(uint32_t) noexcept { return 0; }
+   [[maybe_unused]] static bool cur_arg_is_sret(uint32_t) noexcept { return false; }
 
-        [[maybe_unused]] auto cur_static_allocas() noexcept {
-            // we do not have dynamic allocas in the IR
-            return llvm_iter_range_to_tpde_iter(cur_func.getFunctionBody().getOps<dialect::util::AllocaOp>());
-        }
+   [[maybe_unused]] auto cur_static_allocas() noexcept {
+      // we do not have dynamic allocas in the IR
+      return llvm_iter_range_to_tpde_iter(cur_func.getFunctionBody().getOps<dialect::util::AllocaOp>());
+   }
 
-        [[maybe_unused]] static bool cur_has_dynamic_alloca() noexcept {
-            // the IR does not support dynamic stack allocations
-            return false;
-        }
+   [[maybe_unused]] static bool cur_has_dynamic_alloca() noexcept {
+      // the IR does not support dynamic stack allocations
+      return false;
+   }
 
-        [[maybe_unused]] uint32_t cur_highest_val_idx() const noexcept {
-            return values.size();
-        }
+   [[maybe_unused]] uint32_t cur_highest_val_idx() const noexcept {
+      return values.size();
+   }
 
-        [[maybe_unused]] IRBlockRef cur_entry_block() noexcept {
-            return &cur_func.getFunctionBody().getBlocks().front();
-        }
+   [[maybe_unused]] IRBlockRef cur_entry_block() noexcept {
+      return &cur_func.getFunctionBody().getBlocks().front();
+   }
 
-        [[maybe_unused]] auto cur_blocks() noexcept {
-            return cur_func.getFunctionBody().getBlocks() |
-                   std::views::transform([](mlir::Block &block) {
-                       return &block;
-                   });
-        }
+   [[maybe_unused]] auto cur_blocks() noexcept {
+      return cur_func.getFunctionBody().getBlocks() |
+         std::views::transform([](mlir::Block& block) {
+                return &block;
+             });
+   }
 
-        [[maybe_unused]] auto block_succs(IRBlockRef block) const noexcept {
-            return block->getSuccessors();
-        }
+   [[maybe_unused]] auto block_succs(IRBlockRef block) const noexcept {
+      return block->getSuccessors();
+   }
 
-        [[maybe_unused]] auto block_insts(IRBlockRef block) const noexcept {
-            return block->getOperations() | std::views::transform([](mlir::Operation &op) {
+   [[maybe_unused]] auto block_insts(IRBlockRef block) const noexcept {
+      return block->getOperations() | std::views::transform([](mlir::Operation& op) {
                 return &op;
-            });
-        }
+             });
+   }
 
-        [[maybe_unused]] auto block_phis(IRBlockRef block) const noexcept {
-            return block->getArguments();
-        }
+   [[maybe_unused]] auto block_phis(IRBlockRef block) const noexcept {
+      return block->getArguments();
+   }
 
-        [[maybe_unused]] uint32_t block_info(IRBlockRef block) noexcept {
-            return blockInfoMap[block].first;
-        }
+   [[maybe_unused]] uint32_t block_info(IRBlockRef block) noexcept {
+      return blockInfoMap[block].first;
+   }
 
-        [[maybe_unused]] void block_set_info(IRBlockRef block, const uint32_t info) noexcept {
-            blockInfoMap[block].first = info;
-        }
+   [[maybe_unused]] void block_set_info(IRBlockRef block, const uint32_t info) noexcept {
+      blockInfoMap[block].first = info;
+   }
 
-        [[maybe_unused]] uint32_t block_info2(IRBlockRef block) noexcept {
-            return blockInfoMap[block].second;
-        }
+   [[maybe_unused]] uint32_t block_info2(IRBlockRef block) noexcept {
+      return blockInfoMap[block].second;
+   }
 
-        [[maybe_unused]] void block_set_info2(IRBlockRef block, const uint32_t info) noexcept {
-            blockInfoMap[block].second = info;
-        }
+   [[maybe_unused]] void block_set_info2(IRBlockRef block, const uint32_t info) noexcept {
+      blockInfoMap[block].second = info;
+   }
 
-        [[maybe_unused]] std::string block_fmt_ref(IRBlockRef block) const noexcept {
-            return block->getParentOp()->getName().getStringRef().str();
-        }
+   [[maybe_unused]] std::string block_fmt_ref(IRBlockRef block) const noexcept {
+      return block->getParentOp()->getName().getStringRef().str();
+   }
 
-        [[maybe_unused]] tpde::ValLocalIdx val_local_idx(IRValueRef val) noexcept {
-            return values[val].local_idx;
-        }
+   [[maybe_unused]] tpde::ValLocalIdx val_local_idx(IRValueRef val) noexcept {
+      return values[val].local_idx;
+   }
 
-        [[maybe_unused]] bool val_ignore_in_liveness_analysis(IRValueRef) const noexcept {
-            return false;
-        }
+   [[maybe_unused]] bool val_ignore_in_liveness_analysis(IRValueRef) const noexcept {
+      return false;
+   }
 
-        struct PHIRef {
-            mlir::BlockArgument arg;
+   struct PHIRef {
+      mlir::BlockArgument arg;
 
-            [[maybe_unused]] uint32_t incoming_count() const noexcept {
-                const auto preds = arg.getOwner()->getPredecessors();
-                return std::distance(preds.begin(), preds.end()); // TODO: this is O(n), can we du better?
-            }
+      [[maybe_unused]] uint32_t incoming_count() const noexcept {
+         const auto preds = arg.getOwner()->getPredecessors();
+         return std::distance(preds.begin(), preds.end()); // TODO: this is O(n), can we du better?
+      }
 
-            [[maybe_unused]] IRBlockRef incoming_block_for_slot(const uint32_t slot) const noexcept {
-                assert(slot < incoming_count());
-                const auto preds = arg.getOwner()->getPredecessors();
-                return *std::next(preds.begin(), slot);
-            }
+      [[maybe_unused]] IRBlockRef incoming_block_for_slot(const uint32_t slot) const noexcept {
+         assert(slot < incoming_count());
+         const auto preds = arg.getOwner()->getPredecessors();
+         return *std::next(preds.begin(), slot);
+      }
 
-            [[maybe_unused]] IRValueRef incoming_val_for_block(IRBlockRef predecessor) const noexcept {
+      [[maybe_unused]] IRValueRef incoming_val_for_block(IRBlockRef predecessor) const noexcept {
 #ifndef NDEBUG
-                const auto preds = arg.getOwner()->getPredecessors();
-                const auto matching_pred = std::find(preds.begin(), preds.end(), predecessor);
-                assert(matching_pred != preds.end() && "Predecessor block not found in predecessors");
-                assert(
-                    std::count(preds.begin(), preds.end(), predecessor) == 1 &&
-                    "Predecessor block found multiple times in predecessors. While this is allowed for MLIR, this is currently not supported by TPDE, especially with different edge-values");
+         const auto preds = arg.getOwner()->getPredecessors();
+         const auto matching_pred = std::find(preds.begin(), preds.end(), predecessor);
+         assert(matching_pred != preds.end() && "Predecessor block not found in predecessors");
+         assert(
+            std::count(preds.begin(), preds.end(), predecessor) == 1 &&
+            "Predecessor block found multiple times in predecessors. While this is allowed for MLIR, this is currently not supported by TPDE, especially with different edge-values");
 #endif
-                mlir::Operation *terminator = predecessor->getTerminator();
-                const mlir::Value incomingVal = mlir::TypeSwitch<mlir::Operation *, mlir::Value>(terminator)
-                        .Case<mlir::cf::BranchOp>([&](mlir::cf::BranchOp br) {
-                            return br.getDestOperands()[arg.getArgNumber()];
-                        })
-                        .Case<mlir::cf::CondBranchOp>([&](mlir::cf::CondBranchOp br) {
-                            if (br.getTrueDest() == arg.getOwner()) {
-                                return br.getTrueDestOperands()[arg.getArgNumber()];
-                            }
-                            if (br.getFalseDest() == arg.getOwner()) {
-                                return br.getFalseDestOperands()[arg.getArgNumber()];
-                            }
-                            assert(0 && "Predecessor block not found in branch operands");
-                            return mlir::Value();
-                        })
-                        .Default([](mlir::Operation *op) {
-                            op->dump();
-                            assert(0);
-                            return mlir::Value();
-                        });
-                assert(incomingVal && "Invalid slot for incoming value");
-                assert(incomingVal.getType() == arg.getType() && "Incoming value type mismatch");
-                return cast<IRValueRef>(incomingVal);
+         mlir::Operation* terminator = predecessor->getTerminator();
+         const mlir::Value incomingVal = mlir::TypeSwitch<mlir::Operation*, mlir::Value>(terminator)
+                                            .Case<mlir::cf::BranchOp>([&](mlir::cf::BranchOp br) {
+                                               return br.getDestOperands()[arg.getArgNumber()];
+                                            })
+                                            .Case<mlir::cf::CondBranchOp>([&](mlir::cf::CondBranchOp br) {
+                                               if (br.getTrueDest() == arg.getOwner()) {
+                                                  return br.getTrueDestOperands()[arg.getArgNumber()];
+                                               }
+                                               if (br.getFalseDest() == arg.getOwner()) {
+                                                  return br.getFalseDestOperands()[arg.getArgNumber()];
+                                               }
+                                               assert(0 && "Predecessor block not found in branch operands");
+                                               return mlir::Value();
+                                            })
+                                            .Default([](mlir::Operation* op) {
+                                               op->dump();
+                                               assert(0);
+                                               return mlir::Value();
+                                            });
+         assert(incomingVal && "Invalid slot for incoming value");
+         assert(incomingVal.getType() == arg.getType() && "Incoming value type mismatch");
+         return cast<IRValueRef>(incomingVal);
+      }
+
+      // looks roughly the same as the above, but does not need to calculate the slot index
+      [[maybe_unused]] IRValueRef incoming_val_for_slot(const uint32_t slot) const noexcept {
+         mlir::Block* predecessor = incoming_block_for_slot(slot);
+         return incoming_val_for_block(predecessor);
+      }
+   };
+
+   [[maybe_unused]] bool val_is_phi(IRValueRef val) const noexcept {
+      return mlir::isa<mlir::BlockArgument>(val);
+   }
+
+   [[maybe_unused]] PHIRef val_as_phi(IRValueRef val) const noexcept {
+      assert(mlir::isa<mlir::BlockArgument>(val) && "Value is not a phi node");
+      return PHIRef{cast<mlir::BlockArgument>(val)};
+   }
+
+   [[maybe_unused]] uint32_t val_alloca_size(IRValueRef val) {
+      assert(mlir::isa<dialect::util::AllocaOp>(val.getDefiningOp()) && "Value is not an alloca operation");
+      auto allocaOp = cast<dialect::util::AllocaOp>(val.getDefiningOp());
+      unsigned count = 1; // default size for an alloca without a size is 1
+      if (const auto size = allocaOp.getSize()) {
+         if (auto const_int = mlir::dyn_cast<mlir::arith::ConstantIntOp>(size.getDefiningOp())) {
+            count = const_int.value();
+         } else if (auto const_index = mlir::dyn_cast<mlir::arith::ConstantIndexOp>(size.getDefiningOp())) {
+            count = const_index.value();
+         } else {
+            getError().emit() << "Value is not an arith int constant\n";
+         }
+      }
+
+      const mlir::TypedValue<dialect::util::RefType> res_ptr = allocaOp.getRef();
+      const mlir::Type element_type = res_ptr.getType().getElementType();
+      const auto size = get_size(element_type);
+      if (!size) {
+         getError().emit() << std::format("Value is not a supported type for alloca size calculation: {}\n",
+                                          element_type.getAbstractType().getName().str());
+         return 1;
+      }
+      return *size * count;
+   }
+
+   [[maybe_unused]] uint32_t val_alloca_align(IRValueRef val) const noexcept {
+      return 1;
+   }
+
+   [[maybe_unused]] std::string value_fmt_ref(IRValueRef val) const noexcept {
+      if (auto* const op = val.getDefiningOp()) {
+         return op->getName().getStringRef().str();
+      }
+      if (const mlir::BlockArgument arg = mlir::dyn_cast<mlir::BlockArgument>(val)) {
+         return std::format("block_arg_{}", arg.getArgNumber());
+      }
+      return "";
+   }
+
+   [[maybe_unused]] auto inst_operands(IRInstRef op) const noexcept {
+      return llvm::TypeSwitch<IRInstRef, mlir::OperandRange>(op)
+         .Case<mlir::cf::BranchOp>([](auto) {
+            // direct branches only have block arguments as operands, their usage is counted via phi nodes
+            return mlir::OperandRange{nullptr, 0};
+         })
+         .Case<mlir::cf::CondBranchOp>([](const auto branch) {
+            return mlir::OperandRange{&branch->getOpOperand(0), 1};
+         })
+         .Default([](const auto op) {
+            auto operands = op->getOperands();
+            if (operands.empty()) {
+               return mlir::OperandRange{nullptr, 0};
             }
+            return operands;
+         });
+   }
 
-            // looks roughly the same as the above, but does not need to calculate the slot index
-            [[maybe_unused]] IRValueRef incoming_val_for_slot(const uint32_t slot) const noexcept {
-                mlir::Block *predecessor = incoming_block_for_slot(slot);
-                return incoming_val_for_block(predecessor);
-            }
-        };
+   [[maybe_unused]] auto inst_results(IRInstRef inst) const noexcept {
+      return inst->getResults();
+   }
 
-        [[maybe_unused]] bool val_is_phi(IRValueRef val) const noexcept {
-            return mlir::isa<mlir::BlockArgument>(val);
-        }
+   [[maybe_unused]] static bool inst_fused(IRInstRef) noexcept {
+      return false;
+   }
 
-        [[maybe_unused]] PHIRef val_as_phi(IRValueRef val) const noexcept {
-            assert(mlir::isa<mlir::BlockArgument>(val) && "Value is not a phi node");
-            return PHIRef{cast<mlir::BlockArgument>(val)};
-        }
+   [[maybe_unused]] std::string inst_fmt_ref(IRInstRef inst) const noexcept {
+      return inst->getName().getStringRef().str();
+   }
 
-        [[maybe_unused]] uint32_t val_alloca_size(IRValueRef val) {
-            assert(mlir::isa<dialect::util::AllocaOp>(val.getDefiningOp()) && "Value is not an alloca operation");
-            auto allocaOp = cast<dialect::util::AllocaOp>(val.getDefiningOp());
-            unsigned count = 1; // default size for an alloca without a size is 1
-            if (const auto size = allocaOp.getSize()) {
-                if (auto const_int = mlir::dyn_cast<mlir::arith::ConstantIntOp>(size.getDefiningOp())) {
-                    count = const_int.value();
-                } else if (auto const_index = mlir::dyn_cast<mlir::arith::ConstantIndexOp>(size.getDefiningOp())) {
-                    count = const_index.value();
-                } else {
-                    getError().emit() << "Value is not an arith int constant\n";
-                }
-            }
+   [[maybe_unused]] static void start_compile() {
+      // pass
+   }
 
-            const mlir::TypedValue<dialect::util::RefType> res_ptr = allocaOp.getRef();
-            const mlir::Type element_type = res_ptr.getType().getElementType();
-            const auto size = get_size(element_type);
-            if (!size) {
-                getError().emit() << std::format("Value is not a supported type for alloca size calculation: {}\n",
-                                                 element_type.getAbstractType().getName().str());
-                return 1;
-            }
-            return *size * count;
-        }
+   [[maybe_unused]] static void end_compile() {
+      // pass
+   }
 
-        [[maybe_unused]] uint32_t val_alloca_align(IRValueRef val) const noexcept {
-            return 1;
-        }
+   [[maybe_unused]] bool switch_func(IRFuncRef func) noexcept {
+      cur_func = func;
+      values.clear();
+      for (auto& block : func.getFunctionBody()) {
+         for (auto arg : block.getArguments())
+            values[arg] = ValInfo{
+               .local_idx = static_cast<tpde::ValLocalIdx>(values.size())};
+         for (auto& op : block) {
+            for (auto result : op.getResults())
+               values[result] = ValInfo{
+                  .local_idx = static_cast<tpde::ValLocalIdx>(values.size())};
+         }
+      }
+      return true;
+   }
 
-        [[maybe_unused]] std::string value_fmt_ref(IRValueRef val) const noexcept {
-            if (auto *const op = val.getDefiningOp()) {
-                return op->getName().getStringRef().str();
-            }
-            if (const mlir::BlockArgument arg = mlir::dyn_cast<mlir::BlockArgument>(val)) {
-                return std::format("block_arg_{}", arg.getArgNumber());
-            }
-            return "";
-        }
+   [[maybe_unused]] void reset() {
+      cur_func = INVALID_FUNC_REF;
+      values.clear();
+   }
+};
 
-        [[maybe_unused]] auto inst_operands(IRInstRef op) const noexcept {
-            return llvm::TypeSwitch<IRInstRef, mlir::OperandRange>(op)
-                    .Case<mlir::cf::BranchOp>([](auto) {
-                        // direct branches only have block arguments as operands, their usage is counted via phi nodes
-                        return mlir::OperandRange{nullptr, 0};
-                    })
-                    .Case<mlir::cf::CondBranchOp>([](const auto branch) {
-                        return mlir::OperandRange{&branch->getOpOperand(0), 1};
-                    })
-                    .Default([](const auto op) {
-                        auto operands = op->getOperands();
-                        if (operands.empty()) {
-                            return mlir::OperandRange{nullptr, 0};
-                        }
-                        return operands;
-                    });
-        }
-
-        [[maybe_unused]] auto inst_results(IRInstRef inst) const noexcept {
-            return inst->getResults();
-        }
-
-        [[maybe_unused]] static bool inst_fused(IRInstRef) noexcept {
-            return false;
-        }
-
-        [[maybe_unused]] std::string inst_fmt_ref(IRInstRef inst) const noexcept {
-            return inst->getName().getStringRef().str();
-        }
-
-        [[maybe_unused]] static void start_compile() {
-            // pass
-        }
-
-        [[maybe_unused]] static void end_compile() {
-            // pass
-        }
-
-        [[maybe_unused]] bool switch_func(IRFuncRef func) noexcept {
-            cur_func = func;
-            values.clear();
-            for (auto &block: func.getFunctionBody()) {
-                for (auto arg: block.getArguments())
-                    values[arg] = ValInfo{
-                        .local_idx = static_cast<tpde::ValLocalIdx>(values.size())
-                    };
-                for (auto &op: block) {
-                    for (auto result: op.getResults())
-                        values[result] = ValInfo{
-                            .local_idx = static_cast<tpde::ValLocalIdx>(values.size())
-                        };
-                }
-            }
-            return true;
-        }
-
-        [[maybe_unused]] void reset() {
-            cur_func = INVALID_FUNC_REF;
-            values.clear();
-        }
-    };
-
-    // NOLINTEND(readability-identifier-naming)
-    IRAdaptor::IRFuncRef IRAdaptor::INVALID_FUNC_REF = nullptr;
-    IRAdaptor::IRValueRef IRAdaptor::INVALID_VALUE_REF = mlir::Value();
+// NOLINTEND(readability-identifier-naming)
+IRAdaptor::IRFuncRef IRAdaptor::INVALID_FUNC_REF = nullptr;
+IRAdaptor::IRValueRef IRAdaptor::INVALID_VALUE_REF = mlir::Value();
 }

--- a/src/execution/baseline/CompilerConfig.hpp
+++ b/src/execution/baseline/CompilerConfig.hpp
@@ -3,11 +3,11 @@
 #include <tpde/x64/CompilerX64.hpp>
 
 namespace lingodb::execution::baseline {
-    // NOLINTBEGIN(readability-identifier-naming)
+// NOLINTBEGIN(readability-identifier-naming)
 
-    // use the default config
-    struct CompilerConfig : tpde::x64::PlatformConfig {
-    };
+// use the default config
+struct CompilerConfig : tpde::x64::PlatformConfig {
+};
 
-    // NOLINTEND(readability-identifier-naming)
+// NOLINTEND(readability-identifier-naming)
 }

--- a/src/execution/baseline/CompilerX64.hpp
+++ b/src/execution/baseline/CompilerX64.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "snippet_encoders_x64.hpp"
 #include "Adaptor.hpp"
 #include "CompilerBase.hpp"
 #include "CompilerConfig.hpp"
+#include "snippet_encoders_x64.hpp"
 
 #include <tpde/ValueRef.hpp>
 #include <tpde/x64/CompilerX64.hpp>

--- a/src/execution/baseline/utils.hpp
+++ b/src/execution/baseline/utils.hpp
@@ -10,106 +10,105 @@
 
 #include <memory>
 
-
 namespace lingodb::execution::baseline {
-    using namespace compiler;
+using namespace compiler;
 
-    class SpdLogSpoof {
-        // storage for the log messages
-        std::ostringstream oss;
-        std::shared_ptr<spdlog::sinks::ostream_sink_mt> ostream_sink;
-        std::shared_ptr<spdlog::logger> logger;
-        std::shared_ptr<spdlog::logger> old_logger;
-        unsigned current_listeners{0};
-        std::mutex mutex;
+class SpdLogSpoof {
+   // storage for the log messages
+   std::ostringstream oss;
+   std::shared_ptr<spdlog::sinks::ostream_sink_mt> ostream_sink;
+   std::shared_ptr<spdlog::logger> logger;
+   std::shared_ptr<spdlog::logger> old_logger;
+   unsigned current_listeners{0};
+   std::mutex mutex;
 
-    public:
-        SpdLogSpoof() {
-        }
+   public:
+   SpdLogSpoof() {
+   }
 
-        ~SpdLogSpoof() {
-            if (current_listeners > 0) {
-                // If we are destructing while still in a spoofed state, we need to restore the old logger
-                // to avoid leaving spdlog in an inconsistent state.
-                assert(old_logger && "SpdLogSpoof destructor called without a valid old logger");
-                spdlog::set_default_logger(old_logger);
-            }
-        }
+   ~SpdLogSpoof() {
+      if (current_listeners > 0) {
+         // If we are destructing while still in a spoofed state, we need to restore the old logger
+         // to avoid leaving spdlog in an inconsistent state.
+         assert(old_logger && "SpdLogSpoof destructor called without a valid old logger");
+         spdlog::set_default_logger(old_logger);
+      }
+   }
 
-        void enter() {
-            std::lock_guard lock(mutex);
-            if (current_listeners == 0) {
-                ostream_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
-                logger = std::make_shared<spdlog::logger>("string_logger", ostream_sink);
-                old_logger = spdlog::default_logger();
-                spdlog::set_default_logger(logger);
-            }
-            current_listeners++;
-        }
+   void enter() {
+      std::lock_guard lock(mutex);
+      if (current_listeners == 0) {
+         ostream_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
+         logger = std::make_shared<spdlog::logger>("string_logger", ostream_sink);
+         old_logger = spdlog::default_logger();
+         spdlog::set_default_logger(logger);
+      }
+      current_listeners++;
+   }
 
-        void exit() {
-           std::lock_guard lock(mutex);
-           assert(current_listeners > 0 && "SpdLogSpoof::exit called without matching enter");
-           current_listeners--;
-           if (current_listeners == 0) {
-              spdlog::set_default_logger(old_logger);
-              ostream_sink.reset();
-              old_logger.reset();
-              logger.reset();
-              oss.clear();
-           }
-        }
+   void exit() {
+      std::lock_guard lock(mutex);
+      assert(current_listeners > 0 && "SpdLogSpoof::exit called without matching enter");
+      current_listeners--;
+      if (current_listeners == 0) {
+         spdlog::set_default_logger(old_logger);
+         ostream_sink.reset();
+         old_logger.reset();
+         logger.reset();
+         oss.clear();
+      }
+   }
 
-        std::string logs() {
-            return oss.str();
-        }
-    };
+   std::string logs() {
+      return oss.str();
+   }
+};
 
-    static std::optional<size_t> get_size(mlir::Type type) noexcept {
-        return mlir::TypeSwitch<mlir::Type, size_t>(type)
-                .Case<mlir::IntegerType, mlir::FloatType>([](auto intType) {
-                    return intType.getIntOrFloatBitWidth() / 8;
-                })
-                .Case<dialect::util::VarLen32Type, dialect::util::BufferType>([](auto) { return 16; })
-                .Case<mlir::TupleType>([](auto t) { return TupleHelper{t}.sizeAndPadding().first; })
-                .Case<mlir::IndexType, dialect::util::RefType>([](auto) { return 8; })
-                .Default([](mlir::Type t) {
-                    t.dump();
-                    assert(0 && "Unsupported type for size calculation");
-                    return 0;
-                });
-    }
+static std::optional<size_t> get_size(mlir::Type type) noexcept {
+   return mlir::TypeSwitch<mlir::Type, size_t>(type)
+      .Case<mlir::IntegerType, mlir::FloatType>([](auto intType) {
+         return intType.getIntOrFloatBitWidth() / 8;
+      })
+      .Case<dialect::util::VarLen32Type, dialect::util::BufferType>([](auto) { return 16; })
+      .Case<mlir::TupleType>([](auto t) { return TupleHelper{t}.sizeAndPadding().first; })
+      .Case<mlir::IndexType, dialect::util::RefType>([](auto) { return 8; })
+      .Default([](mlir::Type t) {
+         t.dump();
+         assert(0 && "Unsupported type for size calculation");
+         return 0;
+      });
+}
 
-    // TODO: remove this as soon as either llvm iters have a richer api or tpde drops some requirements
-    template<typename Iter>
-    struct IRIterWrapper {
-        Iter it;
-        using value_type = typename std::iterator_traits<Iter>::value_type;
+// TODO: remove this as soon as either llvm iters have a richer api or tpde drops some requirements
+template <typename Iter>
+struct IRIterWrapper {
+   Iter it;
+   using value_type = typename std::iterator_traits<Iter>::value_type;
 
-        IRIterWrapper() = default;
+   IRIterWrapper() = default;
 
-        explicit IRIterWrapper(Iter it) : it(it) {
-        }
+   explicit IRIterWrapper(Iter it) : it(it) {
+   }
 
-        IRIterWrapper &operator++() {
-            ++it;
-            return *this;
-        }
+   IRIterWrapper& operator++() {
+      ++it;
+      return *this;
+   }
 
-        value_type operator*() const { return *it; }
-        bool operator!=(const IRIterWrapper &other) const { return it != other.it; }
-        bool operator==(const IRIterWrapper &other) const { return it == other.it; }
-    };
+   value_type operator*() const { return *it; }
+   bool operator!=(const IRIterWrapper& other) const { return it != other.it; }
+   bool operator==(const IRIterWrapper& other) const { return it == other.it; }
+};
 
-    template<typename Iter>
-    struct IRRangeWrapper {
-        IRIterWrapper<Iter> b, e;
-        IRIterWrapper<Iter> begin() const { return b; }
-        IRIterWrapper<Iter> end() const { return e; }
-    };
+template <typename Iter>
+struct IRRangeWrapper {
+   IRIterWrapper<Iter> b, e;
+   IRIterWrapper<Iter> begin() const { return b; }
+   IRIterWrapper<Iter> end() const { return e; }
+};
 
-    template<class Iter>
-    auto llvm_iter_range_to_tpde_iter(llvm::iterator_range<Iter> iter) {
-        return IRRangeWrapper<Iter>{IRIterWrapper<Iter>(iter.begin()), IRIterWrapper<Iter>(iter.end())};
-    }
+template <class Iter>
+auto llvm_iter_range_to_tpde_iter(llvm::iterator_range<Iter> iter) {
+   return IRRangeWrapper<Iter>{IRIterWrapper<Iter>(iter.begin()), IRIterWrapper<Iter>(iter.end())};
+}
 } // lingodb::execution::baseline


### PR DESCRIPTION
Due to updates of clang-format, some rule option values were outdated / incompatible. @jungmair and I fixed those invalid rules and adjusted the `make format` command so that rules are also applied to `*.hpp` header files.