### PR TITLE
Jump Fusion

### DIFF
--- a/src/execution/baseline/BaselineBackend.cpp
+++ b/src/execution/baseline/BaselineBackend.cpp
@@ -17,6 +17,10 @@
 namespace lingodb::execution::baseline {
 using namespace compiler;
 
+// init IRAdaptor static vars
+IRAdaptor::IRFuncRef IRAdaptor::INVALID_FUNC_REF = nullptr;
+IRAdaptor::IRValueRef IRAdaptor::INVALID_VALUE_REF = mlir::Value();
+
 namespace {
 utility::GlobalSetting<std::string> baselineDebugFileOut("system.compilation.baseline_object_out", "");
 } // namespace


### PR DESCRIPTION
Since `cmp` instructions on x64 only manipulate the flags register, we currently expensively store the result of the comparison in a GP-register just to later set flags based on the register again (using a `test` instruction) to then perform a conditional jump (which uses the flags as condition). This is inefficient, since the cmp-jmp-pattern occurs often and can be fused. This PR implements this fusion. Additionally, we also fuse cmp-zext and cmp-sext.