### PR TITLE
fix constLike implementation

### DIFF
--- a/src/compiler/Dialect/DB/Transforms/OptimizeRuntimeFunctions.cpp
+++ b/src/compiler/Dialect/DB/Transforms/OptimizeRuntimeFunctions.cpp
@@ -57,13 +57,13 @@ std::optional<std::string> getConstantString(mlir::Value v) {
    }
    return std::optional<std::string>();
 }
-struct DeterministicConstStringMatcher : public Matcher {
-   DeterministicConstStringMatcher() {}
+struct ConstantDeterministicPatternMatcher : public Matcher {
+   ConstantDeterministicPatternMatcher() {}
    bool matches(mlir::Value v) override {
       auto constStringOpt = getConstantString(v);
       return constStringOpt.has_value() && isDeterministicLikePattern(constStringOpt.value());
    }
-   virtual ~DeterministicConstStringMatcher() {}
+   virtual ~ConstantDeterministicPatternMatcher() {}
 };
 struct StringConstMatcher : public Matcher {
    std::string toMatch;
@@ -129,7 +129,7 @@ class OptimizeRuntimeFunctions : public mlir::PassWrapper<OptimizeRuntimeFunctio
          patterns.insert<ReplaceFnWithFn>(&getContext(), "DateDiff", std::vector<std::shared_ptr<Matcher>>{std::make_shared<StringConstMatcher>("hour"), std::make_shared<AnyMatcher>(), std::make_shared<AnyMatcher>()}, "DateDiffHour");
          patterns.insert<ReplaceFnWithFn>(&getContext(), "DateDiff", std::vector<std::shared_ptr<Matcher>>{std::make_shared<StringConstMatcher>("day"), std::make_shared<AnyMatcher>(), std::make_shared<AnyMatcher>()}, "DateDiffDay");
 
-         patterns.insert<ReplaceFnWithFn>(&getContext(), "Like", std::vector<std::shared_ptr<Matcher>>{std::make_shared<AnyMatcher>(), std::make_shared<DeterministicConstStringMatcher>()}, "ConstLike");
+         patterns.insert<ReplaceFnWithFn>(&getContext(), "Like", std::vector<std::shared_ptr<Matcher>>{std::make_shared<AnyMatcher>(), std::make_shared<ConstantDeterministicPatternMatcher>()}, "ConstLike");
          if (mlir::applyPatternsGreedily(getOperation().getRegion(), std::move(patterns)).failed()) {
             assert(false && "should not happen");
          }

--- a/test/lit/DB/stringops.mlir
+++ b/test/lit/DB/stringops.mlir
@@ -264,6 +264,18 @@ module {
         %r25 = db.runtime_call "Like"(%c25, %like21) : (!db.string, !db.string) -> (i1)
         db.runtime_call "DumpValue"(%r25) : (i1) -> ()
         //CHECK: bool(false)
+
+        // Non deterministic patterns
+        %like22 = db.constant("_x%ab_cd_ab%_d_ef"): !db.string
+        %c26 = db.constant("xxababccdaabdeefddef") : !db.string
+        %r26 = db.runtime_call "Like"(%c26, %like22) : (!db.string, !db.string) -> (i1)
+        db.runtime_call "DumpValue"(%r26) : (i1) -> ()
+        //CHECK: bool(true)
+
+        %c27 = db.constant("yxabxcdxabdxef") : !db.string
+        %r27 = db.runtime_call "Like"(%c27, %like22) : (!db.string, !db.string) -> (i1)
+        db.runtime_call "DumpValue"(%r27) : (i1) -> ()
+        //CHECK: bool(false)
         return
     }
 }

--- a/test/lit/DB/stringops.mlir
+++ b/test/lit/DB/stringops.mlir
@@ -229,7 +229,41 @@ module {
         db.runtime_call "DumpValue"(%r19) : (i1) -> ()
         //CHECK: bool(true)
 
+        %like16 = db.constant("%Jos"): !db.string
+        %c20 = db.constant("Jose!!") : !db.string
+        %r20 = db.runtime_call "Like"(%c20, %like16) : (!db.string, !db.string) -> (i1)
+        db.runtime_call "DumpValue"(%r20) : (i1) -> ()
+        //CHECK: bool(false)
 
+        %like17 = db.constant("a_b%abc%%_aáé"): !db.string
+        %c21 = db.constant("aabxxabcxaáéxaáé") : !db.string
+        %r21 = db.runtime_call "Like"(%c21, %like17) : (!db.string, !db.string) -> (i1)
+        db.runtime_call "DumpValue"(%r21) : (i1) -> ()
+        //CHECK: bool(true)
+
+        %like18 = db.constant("a_b%%%_aáé"): !db.string
+        %c22 = db.constant("aabxxxxaáéáé") : !db.string
+        %r22 = db.runtime_call "Like"(%c22, %like18) : (!db.string, !db.string) -> (i1)
+        db.runtime_call "DumpValue"(%r22) : (i1) -> ()
+        //CHECK: bool(false)
+
+        %like19 = db.constant("a_b%abc%bc"): !db.string
+        %c23 = db.constant("aababc") : !db.string
+        %r23 = db.runtime_call "Like"(%c23, %like19) : (!db.string, !db.string) -> (i1)
+        db.runtime_call "DumpValue"(%r23) : (i1) -> ()
+        //CHECK: bool(false)
+
+        %like20 = db.constant("a_b%abc%_bc"): !db.string
+        %c24 = db.constant("aababcabcbbc") : !db.string
+        %r24 = db.runtime_call "Like"(%c24, %like20) : (!db.string, !db.string) -> (i1)
+        db.runtime_call "DumpValue"(%r24) : (i1) -> ()
+        //CHECK: bool(true)
+
+        %like21 = db.constant("a_b%__%abc%"): !db.string
+        %c25 = db.constant("abbabcaa") : !db.string
+        %r25 = db.runtime_call "Like"(%c25, %like21) : (!db.string, !db.string) -> (i1)
+        db.runtime_call "DumpValue"(%r25) : (i1) -> ()
+        //CHECK: bool(false)
         return
     }
 }


### PR DESCRIPTION
The current implementation of the SQL LIKE operator for constant patterns is semantically incorrect.

This PR fixes the implementation of the constLike function and changes the optimization rule in OptimizeRuntimeFunctions.cpp to only use exchange the default LIKE implementation for the constLike implementation for constant pattern strings that are deterministic.

Deterministic means that sub patterns enclosed by '%' (i.e. "%abc%") cannot contain patterns such as "%a_bc%".
They can contain either just deterministic characters ("%abc%") or just placeholders ("%__%").
