### PR TITLE
Generate optimized code path for certain string comparisions

### DIFF
--- a/include/lingodb/compiler/Dialect/util/UtilOps.td
+++ b/include/lingodb/compiler/Dialect/util/UtilOps.td
@@ -52,6 +52,11 @@ def VarLenCmp : Util_Op<"varlen32_cmp"> {
     let results = (outs I1: $eq, I1: $needs_detailed_eval);
     let assemblyFormat = " $left `,` $right attr-dict";
 }
+def VarLenCmpSimple : Util_Op<"varlen32_cmp_simple"> {
+    let arguments = (ins VarLen32Type:$left, VarLen32Type:$right);
+    let results = (outs I1: $eq);
+    let assemblyFormat = " $left `,` $right attr-dict";
+}
 def VarLenTryCheapHash : Util_Op<"varlen32_try_cheap_hash"> {
     let arguments = (ins VarLen32Type:$varlen);
     let results = (outs I1: $complete, Index:$hash);

--- a/src/compiler/Conversion/DBToStd/LowerToStd.cpp
+++ b/src/compiler/Conversion/DBToStd/LowerToStd.cpp
@@ -326,6 +326,17 @@ class StringCmpOpLowering : public OpConversionPattern<db::CmpOp> {
       }
       return true;
    }
+   bool smallConstString(mlir::Value val) const {
+      if (auto constOp = val.getDefiningOp<db::ConstantOp>()) {
+         if (auto strAttr = mlir::dyn_cast<mlir::StringAttr>(constOp.getValue())) {
+            auto str = strAttr.getValue();
+            if (str.size() <= 12) {
+               return true;
+            }
+         }
+      }
+      return false;
+   }
    LogicalResult matchAndRewrite(db::CmpOp cmpOp, OpAdaptor adaptor, ConversionPatternRewriter& rewriter) const override {
       using namespace lingodb::compiler::runtime;
       auto type = cmpOp.getLeft().getType();
@@ -337,13 +348,18 @@ class StringCmpOpLowering : public OpConversionPattern<db::CmpOp> {
       Value right = adaptor.getRight();
       switch (cmpOp.getPredicate()) {
          case db::DBCmpPredicate::eq: {
-            auto varlenCmp = rewriter.create<util::VarLenCmp>(cmpOp->getLoc(), rewriter.getI1Type(), rewriter.getI1Type(), left, right);
-            // TODO: this should be speculated to be **false** to move longer string comparisons out of the hot path
-            res = rewriter.create<mlir::scf::IfOp>(
-                             cmpOp->getLoc(), varlenCmp.getNeedsDetailedEval(), [&](mlir::OpBuilder& builder, mlir::Location loc) {
+            if (smallConstString(cmpOp.getLeft()) || smallConstString(cmpOp.getRight())) {
+               // for small constant strings, we can use direct comparison
+               res = rewriter.create<util::VarLenCmpSimple>(cmpOp->getLoc(), rewriter.getI1Type(), left, right);
+            } else {
+               auto varlenCmp = rewriter.create<util::VarLenCmp>(cmpOp->getLoc(), rewriter.getI1Type(), rewriter.getI1Type(), left, right);
+               // TODO: this should be speculated to be **false** to move longer string comparisons out of the hot path
+               res = rewriter.create<mlir::scf::IfOp>(
+                                cmpOp->getLoc(), varlenCmp.getNeedsDetailedEval(), [&](mlir::OpBuilder& builder, mlir::Location loc) {
                                                          auto rtCmp=StringRuntime::compareEq(rewriter, cmpOp->getLoc())({left, right})[0];
                                                          builder.create<mlir::scf::YieldOp>(loc, rtCmp); }, [&](mlir::OpBuilder& builder, mlir::Location loc) { builder.create<mlir::scf::YieldOp>(loc, varlenCmp.getEq()); })
-                     .getResult(0);
+                        .getResult(0);
+            }
             break;
          }
          case db::DBCmpPredicate::neq:

--- a/src/compiler/Conversion/UtilToLLVM/LowerToLLVM.cpp
+++ b/src/compiler/Conversion/UtilToLLVM/LowerToLLVM.cpp
@@ -314,6 +314,17 @@ class VarLenCmpLowering : public OpConversionPattern<util::VarLenCmp> {
       return success();
    }
 };
+class VarLenCmpSimpleLowering : public OpConversionPattern<util::VarLenCmpSimple> {
+   public:
+   using OpConversionPattern<util::VarLenCmpSimple>::OpConversionPattern;
+   LogicalResult matchAndRewrite(util::VarLenCmpSimple op, OpAdaptor adaptor, ConversionPatternRewriter& rewriter) const override {
+      auto loc = op->getLoc();
+
+      Value totalEq = rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::eq, adaptor.getLeft(), adaptor.getRight());
+      rewriter.replaceOp(op, totalEq);
+      return success();
+   }
+};
 class VarLenTryCheapHashLowering : public OpConversionPattern<util::VarLenTryCheapHash> {
    public:
    using OpConversionPattern<util::VarLenTryCheapHash>::OpConversionPattern;
@@ -596,6 +607,7 @@ void util::populateUtilToLLVMConversionPatterns(LLVMTypeConverter& typeConverter
    patterns.add<CreateConstVarLenLowering>(typeConverter, patterns.getContext());
    patterns.add<VarLenGetLenLowering>(typeConverter, patterns.getContext());
    patterns.add<VarLenCmpLowering>(typeConverter, patterns.getContext());
+   patterns.add<VarLenCmpSimpleLowering>(typeConverter, patterns.getContext());
    patterns.add<VarLenTryCheapHashLowering>(typeConverter, patterns.getContext());
    patterns.add<HashCombineLowering>(typeConverter, patterns.getContext());
    patterns.add<Hash64Lowering>(typeConverter, patterns.getContext());

--- a/src/execution/CEmitter.cpp
+++ b/src/execution/CEmitter.cpp
@@ -431,6 +431,16 @@ LogicalResult printOperation(CppEmitter& emitter, util::VarLenCmp op) {
    os << "= " << left << ".getLen()>12 && " << left << ".getLen()==" << right << ".getLen() &&" << left << ".first4==" << right << ".first4";
    return success();
 }
+LogicalResult printOperation(CppEmitter& emitter, util::VarLenCmpSimple op) {
+   if (failed(emitter.emitVariableDeclaration(op->getResult(0), false))) {
+      return failure();
+   }
+   raw_ostream& os = emitter.ostream();
+   auto left = emitter.getOrCreateName(op.getLeft());
+   auto right = emitter.getOrCreateName(op.getRight());
+   os << "= *reinterpret_cast<__int128*>(&" << left << ") ==*reinterpret_cast<__int128*>(&" << right << ");\n";
+   return success();
+}
 LogicalResult printOperation(CppEmitter& emitter, util::VarLenTryCheapHash op) {
    if (failed(emitter.emitVariableDeclaration(op->getResult(0), false))) {
       return failure();
@@ -1331,7 +1341,7 @@ LogicalResult CppEmitter::emitOperation(Operation& op, bool trailingSemicolon) {
             }
          })
          // SCF ops.
-         .Case<util::GenericMemrefCastOp, util::TupleElementPtrOp, util::ArrayElementPtrOp, util::LoadOp, util::StoreOp, util::AllocOp, util::AllocaOp, util::CreateConstVarLen, util::UndefOp, util::BufferCastOp, util::BufferCreateOp, util::DeAllocOp, util::InvalidRefOp, util::IsRefValidOp, util::SizeOfOp, util::PackOp, util::CreateVarLen, util::Hash64, util::HashCombine, util::HashVarLen, util::PtrTagMatches, util::UnTagPtr, util::BufferGetRef, util::BufferGetElementRef, util::BufferGetLen, util::VarLenCmp, util::VarLenGetLen, util::GetTupleOp, util::VarLenTryCheapHash>(
+         .Case<util::GenericMemrefCastOp, util::TupleElementPtrOp, util::ArrayElementPtrOp, util::LoadOp, util::StoreOp, util::AllocOp, util::AllocaOp, util::CreateConstVarLen, util::UndefOp, util::BufferCastOp, util::BufferCreateOp, util::DeAllocOp, util::InvalidRefOp, util::IsRefValidOp, util::SizeOfOp, util::PackOp, util::CreateVarLen, util::Hash64, util::HashCombine, util::HashVarLen, util::PtrTagMatches, util::UnTagPtr, util::BufferGetRef, util::BufferGetElementRef, util::BufferGetLen, util::VarLenCmp, util::VarLenCmpSimple, util::VarLenGetLen, util::GetTupleOp, util::VarLenTryCheapHash>(
             [&](auto op) { return printOperation(*this, op); })
          .Case<util::ToMemrefOp, memref::AtomicRMWOp>(
             [&](auto op) { return printOperation(*this, op); })

--- a/src/execution/baseline/CompilerBase.hpp
+++ b/src/execution/baseline/CompilerBase.hpp
@@ -1060,6 +1060,12 @@ struct IRCompilerBase : tpde::CompilerBase<IRAdaptor, Derived, Config> {
       auto more_cmp_res_vr = this->result_ref(op.getNeedsDetailedEval());
       return derived()->encode_util_varlen_cmp(lhs_vr.part(0), lhs_vr.part(1), rhs_vr.part(0), rhs_vr.part(1), eq_res_vr.part(0), more_cmp_res_vr.part(0));
    }
+   bool compile_util_varlen_cmp_simple_op(dialect::util::VarLenCmpSimple op) {
+      auto lhs_vr = this->val_ref(op.getLeft());
+      auto rhs_vr = this->val_ref(op.getRight());
+      auto eq_res_vr = this->result_ref(op.getEq());
+      return derived()->encode_util_varlen_cmp_simple(lhs_vr.part(0), lhs_vr.part(1), rhs_vr.part(0), rhs_vr.part(1), eq_res_vr.part(0));
+   }
 
    bool compile_arith_cmp_float_op(mlir::arith::CmpFOp op) {
       const mlir::Value lhs = op.getLhs();
@@ -1491,6 +1497,7 @@ struct IRCompilerBase : tpde::CompilerBase<IRAdaptor, Derived, Config> {
             return compile_util_get_tuple_op(op);
          })
          .template Case<dialect::util::VarLenCmp>([&](auto op) { return compile_util_varlen_cmp_op(op); })
+         .template Case<dialect::util::VarLenCmpSimple>([&](auto op) { return compile_util_varlen_cmp_simple_op(op); })
          .Default([&](IRInstRef op) {
             error.emit() << "Encountered unimplemented instruction: " << op->getName().getStringRef().str()
                          << "\n";

--- a/src/execution/baseline/snippets_x64.c
+++ b/src/execution/baseline/snippets_x64.c
@@ -193,6 +193,10 @@ UtilTryCheapHashRes util_varlen_try_cheap_hash(__uint128_t varlen) {
 }
 
 typedef struct UtilVarLenRes { uint64_t totalEqual; uint64_t needsDetailedComp; } UtilVarLenRes;
+bool util_varlen_cmp_simple(__uint128_t lhs, __uint128_t rhs) {
+   return (lhs == rhs);
+}
+
 UtilVarLenRes util_varlen_cmp(__uint128_t lhs, __uint128_t rhs) {
     // cmp lengths + first 4 chars
     uint64_t first64Left = (uint64_t)(lhs);


### PR DESCRIPTION
If a string value is compared with a constant that is <= 12 bytes, we can directly compare the 128-bit representation