### PR TITLE
Fix TPDE Backend by checking if register is already loaded before loading it

### DIFF
--- a/src/execution/baseline/CompilerA64.hpp
+++ b/src/execution/baseline/CompilerA64.hpp
@@ -115,13 +115,13 @@ struct IRCompilerA64
       if (int_width == 128) {
          auto lhs_lo = lhs.part(0);
          auto lhs_hi = lhs.part(1);
-         auto lhs_reg_lo = lhs_lo.load_to_reg();
-         auto lhs_reg_hi = lhs_hi.load_to_reg();
+         auto lhs_reg_lo = lhs_lo.has_reg() ? lhs_lo.cur_reg() : lhs_lo.load_to_reg();
+         auto lhs_reg_hi = lhs_hi.has_reg() ? lhs_hi.cur_reg() : lhs_hi.load_to_reg();
 
          auto rhs_lo = rhs.part(0);
          auto rhs_hi = rhs.part(1);
-         auto rhs_reg_lo = rhs_lo.load_to_reg();
-         auto rhs_reg_hi = rhs_hi.load_to_reg();
+         auto rhs_reg_lo = rhs_lo.has_reg() ? rhs_lo.cur_reg() : rhs_lo.load_to_reg();
+         auto rhs_reg_hi = rhs_hi.has_reg() ? rhs_hi.cur_reg() : rhs_hi.load_to_reg();
 
          if (jump == Jump::Jeq || jump == Jump::Jne) {
             // Use CCMP for equality
@@ -174,7 +174,7 @@ struct IRCompilerA64
                   return false;
             }
          } else {
-            auto rhs_reg = rhs_pr.load_to_reg();
+            auto rhs_reg = rhs_pr.has_reg() ? rhs_pr.cur_reg() : rhs_pr.load_to_reg();
             switch (int_width) {
                case 1:
                case 8:
@@ -237,7 +237,7 @@ struct IRCompilerA64
       auto* const false_block = op.getFalseDest();
 
       auto [_, cond_ref] = this->val_ref_single(op.getCondition());
-      const auto cond_reg = cond_ref.load_to_reg();
+      const auto cond_reg = cond_ref.has_reg() ? cond_ref.cur_reg() : cond_ref.load_to_reg();
       ASM(TSTwi, cond_reg, 1);
 
       generate_cond_branch(Jump::Jne, true_block, false_block);

--- a/src/execution/baseline/CompilerBase.hpp
+++ b/src/execution/baseline/CompilerBase.hpp
@@ -342,14 +342,14 @@ struct IRCompilerBase : tpde::CompilerBase<IRAdaptor, Derived, Config> {
 
       if (idx) {
          if (auto idx_op = mlir::dyn_cast_or_null<mlir::arith::ConstantIndexOp>(idx.getDefiningOp())) {
-            AsmReg ptr_reg = base.load_to_reg();
+            AsmReg ptr_reg = base.has_reg() ? base.cur_reg() : base.load_to_reg();
             return GenericValuePart{
                Expr{
                   std::move(ptr_reg), static_cast<int64_t>(static_cast<size_t>(idx_op.value()) * (*elem_size))}};
          }
          auto [_, idx_ref] = this->val_ref_single(idx);
-         auto generic_ptr_expr = Expr{base.load_to_reg()};
-         generic_ptr_expr.index = idx_ref.load_to_reg();
+         auto generic_ptr_expr = Expr{base.has_reg() ? base.cur_reg() : base.load_to_reg()};
+         generic_ptr_expr.index = idx_ref.has_reg() ? idx_ref.cur_reg() : idx_ref.load_to_reg();
          generic_ptr_expr.scale = *elem_size;
          return GenericValuePart{std::move(generic_ptr_expr)};
       }
@@ -572,7 +572,8 @@ struct IRCompilerBase : tpde::CompilerBase<IRAdaptor, Derived, Config> {
       auto res_vr = this->result_ref(dst);
 
       // create a base + offset expression
-      AsmReg base_reg = base_vr.part(0).load_to_reg();
+      auto base_vr_part0 = base_vr.part(0);
+      AsmReg base_reg = base_vr_part0.has_reg() ? base_vr_part0.cur_reg() : base_vr_part0.load_to_reg();
       GenericValuePart addr = typename GenericValuePart::Expr{base_reg, elementOffset};
 
       // load value to register (e.g. mov + add / lea for x86_64)
@@ -596,7 +597,7 @@ struct IRCompilerBase : tpde::CompilerBase<IRAdaptor, Derived, Config> {
       auto res = this->result_ref(dst);
 
       // create a base + offset expression
-      AsmReg base_reg = base_vr.load_to_reg();
+      AsmReg base_reg = base_vr.has_reg() ? base_vr.cur_reg() : base_vr.load_to_reg();
       GenericValuePart offset_expr = typename GenericValuePart::Expr{std::move(base_reg), elementOffset};
       return mlir::TypeSwitch<mlir::Type, bool>(op.getType())
          .Case([&](const mlir::IntegerType t) {
@@ -645,7 +646,7 @@ struct IRCompilerBase : tpde::CompilerBase<IRAdaptor, Derived, Config> {
       assert(val_parts(base_ref).count() == 1);
       auto [_, base_vr] = this->val_ref_single(base_ref);
       // create a base + offset expression
-      AsmReg base_reg = base_vr.load_to_reg();
+      AsmReg base_reg = base_vr.has_reg() ? base_vr.cur_reg() : base_vr.load_to_reg();
       GenericValuePart offset_expr = typename GenericValuePart::Expr{std::move(base_reg), elementOffset};
       auto in_vr = this->val_ref(in);
       return mlir::TypeSwitch<mlir::Type, bool>(in.getType())
@@ -690,12 +691,12 @@ struct IRCompilerBase : tpde::CompilerBase<IRAdaptor, Derived, Config> {
       auto res_vr = this->result_ref(op.getRes());
       {
          ScratchReg res_scratch{derived()};
-         derived()->mov(res_scratch.alloc_gp(), src_vr.part(0).load_to_reg(), 8);
+         derived()->mov(res_scratch.alloc_gp(), src_vr.part(0).has_reg() ? src_vr.part(0).cur_reg() : src_vr.part(0).load_to_reg(), 8);
          res_vr.part(0).set_value(std::move(res_scratch));
       }
       {
          ScratchReg res_scratch{derived()};
-         derived()->mov(res_scratch.alloc_gp(), src_vr.part(1).load_to_reg(), 8);
+         derived()->mov(res_scratch.alloc_gp(), src_vr.part(1).has_reg() ? src_vr.part(1).cur_reg() : src_vr.part(1).load_to_reg(), 8);
          res_vr.part(1).set_value(std::move(res_scratch));
       }
       return true;

--- a/src/execution/baseline/CompilerX64.hpp
+++ b/src/execution/baseline/CompilerX64.hpp
@@ -119,8 +119,8 @@ struct IRCompilerX64
 
          auto rhs_lo = rhs.part(0);
          auto rhs_hi = rhs.part(1);
-         auto rhs_reg_lo = rhs_lo.load_to_reg();
-         auto rhs_reg_hi = rhs_hi.load_to_reg();
+         auto rhs_reg_lo = rhs_lo.has_reg() ? rhs_lo.cur_reg() : rhs_lo.load_to_reg();
+         auto rhs_reg_hi = rhs_hi.has_reg() ? rhs_hi.cur_reg() : rhs_hi.load_to_reg();
 
          // Compare the ints using carried subtraction
          if ((jump == Jump::je) || (jump == Jump::jne)) {
@@ -134,7 +134,7 @@ struct IRCompilerX64
             ASM(OR64rr, res_scratch.cur_reg(), scratch.cur_reg());
          } else {
             auto lhs_lo = lhs.part(0);
-            auto lhs_reg_lo = lhs_lo.load_to_reg();
+            auto lhs_reg_lo = lhs_lo.has_reg() ? lhs_lo.cur_reg() : lhs_lo.load_to_reg();
             auto lhs_high_tmp =
                lhs.part(1).reload_into_specific_fixed(this, res_scratch.alloc_gp());
 
@@ -184,7 +184,7 @@ struct IRCompilerX64
                   return false;
             }
          } else {
-            auto rhs_reg = rhs_pr.load_to_reg();
+            auto rhs_reg = rhs_pr.has_reg() ? rhs_pr.cur_reg() : rhs_pr.load_to_reg();
             switch (int_width) {
                case 1:
                case 8:
@@ -248,7 +248,7 @@ struct IRCompilerX64
       auto* const false_block = op.getFalseDest();
 
       auto [_, cond_ref] = this->val_ref_single(op.getCondition());
-      const auto cond_reg = cond_ref.load_to_reg();
+      const auto cond_reg = cond_ref.has_reg() ? cond_ref.cur_reg() : cond_ref.load_to_reg();
       ASM(TEST32ri, cond_reg, 1);
 
       return generate_conditional_branch(Jump::jne, true_block, false_block);


### PR DESCRIPTION
During graphalg testing, I had segfaults in the X64: compile_arith_cmp_int_op, as there were quite a few loads without checks. 

Now all register loads are checked before loaded.