### PR TITLE
add trivial join elimination pass

### DIFF
--- a/include/lingodb/compiler/Dialect/RelAlg/Passes.h
+++ b/include/lingodb/compiler/Dialect/RelAlg/Passes.h
@@ -29,6 +29,8 @@ std::unique_ptr<mlir::Pass> createReduceGroupByKeysPass();
 std::unique_ptr<mlir::Pass> createExpandTransitiveEqualities();
 std::unique_ptr<mlir::Pass> createEliminateNullableTypesPass();
 
+std::unique_ptr<mlir::Pass> createEliminateTrivialJoinPass();
+
 std::unique_ptr<mlir::Pass> createSimplifyAggregationsPass();
 std::unique_ptr<mlir::Pass> createAttachMetaDataPass(catalog::Catalog& db);
 std::unique_ptr<mlir::Pass> createDetachMetaDataPass();

--- a/src/compiler/Dialect/RelAlg/CMakeLists.txt
+++ b/src/compiler/Dialect/RelAlg/CMakeLists.txt
@@ -11,6 +11,7 @@ add_mlir_dialect_library(MLIRRelAlg
         Transforms/DecomposeLambdas.cpp
         Transforms/CombinePredicates.cpp
         Transforms/OptimizeImplementations.cpp
+        Transforms/EliminateTrivialJoin.cpp
         Transforms/PropagateConstraints.cpp
         Transforms/IntroduceTmp.cpp
         Transforms/CommonSubtreeElimination.cpp

--- a/src/compiler/Dialect/RelAlg/Passes.cpp
+++ b/src/compiler/Dialect/RelAlg/Passes.cpp
@@ -29,10 +29,11 @@ void relalg::createQueryOptPipeline(mlir::OpPassManager& pm, lingodb::catalog::C
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createUnnestingPass());
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createColumnFoldingPass());
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createDecomposeLambdasPass());
-   pm.addNestedPass<mlir::func::FuncOp>(relalg::createPushdownPass());
    if (catalog) {
       pm.addNestedPass<mlir::func::FuncOp>(relalg::createAttachMetaDataPass(*catalog));
    }
+   pm.addNestedPass<mlir::func::FuncOp>(relalg::createEliminateTrivialJoinPass());
+   pm.addNestedPass<mlir::func::FuncOp>(relalg::createPushdownPass());
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createReduceGroupByKeysPass());
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createExpandTransitiveEqualities());
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createOptimizeJoinOrderPass());
@@ -40,7 +41,6 @@ void relalg::createQueryOptPipeline(mlir::OpPassManager& pm, lingodb::catalog::C
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createCombinePredicatesPass());
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createEliminateNullableTypesPass());
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createOptimizeImplementationsPass());
-   pm.addNestedPass<mlir::func::FuncOp>(relalg::createEliminateTrivialJoinPass());
    if (catalog) {
       pm.addNestedPass<mlir::func::FuncOp>(relalg::createDetachMetaDataPass());
    }

--- a/src/compiler/Dialect/RelAlg/Passes.cpp
+++ b/src/compiler/Dialect/RelAlg/Passes.cpp
@@ -40,6 +40,7 @@ void relalg::createQueryOptPipeline(mlir::OpPassManager& pm, lingodb::catalog::C
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createCombinePredicatesPass());
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createEliminateNullableTypesPass());
    pm.addNestedPass<mlir::func::FuncOp>(relalg::createOptimizeImplementationsPass());
+   pm.addNestedPass<mlir::func::FuncOp>(relalg::createEliminateTrivialJoinPass());
    if (catalog) {
       pm.addNestedPass<mlir::func::FuncOp>(relalg::createDetachMetaDataPass());
    }
@@ -71,6 +72,9 @@ void relalg::registerQueryOptimizationPasses() {
    });
    ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
       return relalg::createOptimizeImplementationsPass();
+   });
+   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+      return relalg::createEliminateTrivialJoinPass();
    });
    ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
       return relalg::createIntroduceTmpPass();

--- a/src/compiler/Dialect/RelAlg/Transforms/EliminateTrivialJoin.cpp
+++ b/src/compiler/Dialect/RelAlg/Transforms/EliminateTrivialJoin.cpp
@@ -1,6 +1,7 @@
+#include "lingodb/compiler/Dialect/DB/IR/DBOps.h"
 #include "lingodb/compiler/Dialect/RelAlg/IR/RelAlgOps.h"
-#include "lingodb/compiler/Dialect/RelAlg/IR/RelAlgOpsInterfaces.h"
 #include "lingodb/compiler/Dialect/RelAlg/Passes.h"
+#include "lingodb/compiler/Dialect/TupleStream/TupleStreamOps.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
@@ -9,36 +10,77 @@
 namespace {
 using namespace lingodb::compiler::dialect;
 
+/// Flatten the value expression under the join predicate's return into AND leaves
+static void collectAndLeaves(mlir::Value v, llvm::SmallVectorImpl<mlir::Value>& leaves) {
+   if (auto andOp = mlir::dyn_cast_or_null<db::AndOp>(v.getDefiningOp())) {
+      for (mlir::Value operand : andOp->getOperands()) {
+         collectAndLeaves(operand, leaves);
+      }
+      return;
+   }
+   leaves.push_back(v);
+}
+
+/// From the join predicate region, collect columns that appear on the right input for each left–right equality (hash join key on the right).
+static relalg::ColumnSet extractRightJoinKeyColumns(relalg::OuterJoinOp outerJoin, relalg::AvailabilityCache& cache) {
+   relalg::ColumnSet outRightKeys;
+   auto* term = outerJoin.getPredicateBlock().getTerminator();
+   auto returnOp = mlir::dyn_cast<tuples::ReturnOp>(term);
+   if (!returnOp || returnOp.getNumOperands() == 0) {
+      return outRightKeys;
+   }
+
+   llvm::SmallVector<mlir::Value, 8> leaves;
+   collectAndLeaves(returnOp.getOperand(0), leaves);
+   if (leaves.empty()) {
+      return outRightKeys;
+   }
+
+   auto left = mlir::cast<Operator>(outerJoin.getLeft().getDefiningOp());
+   auto right = mlir::cast<Operator>(outerJoin.getRight().getDefiningOp());
+   auto availableLeft = left.getAvailableColumns(cache);
+   auto availableRight = right.getAvailableColumns(cache);
+
+   outRightKeys = relalg::ColumnSet();
+   for (mlir::Value leaf : leaves) {
+      auto* defOp = leaf.getDefiningOp();
+      auto cmpOp = mlir::dyn_cast_or_null<relalg::CmpOpInterface>(defOp);
+      if (!cmpOp || !cmpOp.isEqualityPred(false)) {
+         continue;
+      }
+      auto getLeftCol = mlir::dyn_cast_or_null<tuples::GetColumnOp>(cmpOp.getLeft().getDefiningOp());
+      auto getRightCol = mlir::dyn_cast_or_null<tuples::GetColumnOp>(cmpOp.getRight().getDefiningOp());
+      if (!getLeftCol || !getRightCol) {
+         continue;
+      }
+      relalg::ColumnSet leftCols = relalg::ColumnSet::from(getLeftCol.getAttr());
+      relalg::ColumnSet rightCols = relalg::ColumnSet::from(getRightCol.getAttr());
+
+      if (leftCols.isSubsetOf(availableLeft) && rightCols.isSubsetOf(availableRight)) {
+         outRightKeys.insert(rightCols);
+      } else if (leftCols.isSubsetOf(availableRight) && rightCols.isSubsetOf(availableLeft)) {
+         outRightKeys.insert(leftCols);
+      }
+   }
+   return outRightKeys;
+}
+
 class EliminateTrivialJoin final : public mlir::OpRewritePattern<relalg::OuterJoinOp> {
    public:
    using mlir::OpRewritePattern<relalg::OuterJoinOp>::OpRewritePattern;
 
    mlir::LogicalResult matchAndRewrite(relalg::OuterJoinOp outerJoinOp, mlir::PatternRewriter& rewriter) const override {
-      bool useHash = outerJoinOp->hasAttr("useHashJoin");
-      if (!useHash) {
+      if (!outerJoinOp.getMapping().empty()) {
          return mlir::failure();
-      }
-      auto nullsEqual = outerJoinOp->getAttrOfType<mlir::ArrayAttr>("nullsEqual");
-      for (auto nE : nullsEqual) {
-         bool nullequal = mlir::cast<mlir::IntegerAttr>(nE).getInt();
-         if (nullequal) {
-            return mlir::failure();
-         }
       }
 
       auto right = mlir::dyn_cast<Operator>(outerJoinOp.getRight().getDefiningOp());
-      if (!outerJoinOp->hasAttr("rightHash")) {
-         return mlir::failure();
-      }
 
-      auto rightKeysAttr = mlir::cast<mlir::ArrayAttr>(outerJoinOp->getAttrOfType<mlir::ArrayAttr>("rightHash"));
-      auto rightKeyCols = relalg::ColumnSet::fromArrayAttr(rightKeysAttr);
+      relalg::AvailabilityCache cache;
+      auto rightKeyCols = extractRightJoinKeyColumns(outerJoinOp, cache);
 
       auto fds = right.getFDs();
-      if (!fds.isDuplicateFreeKey(rightKeyCols)) {
-         return mlir::failure();
-      }
-      if (!outerJoinOp.getMapping().empty()) {
+      if (rightKeyCols.empty() || !fds.isDuplicateFreeKey(rightKeyCols)) {
          return mlir::failure();
       }
 

--- a/src/compiler/Dialect/RelAlg/Transforms/EliminateTrivialJoin.cpp
+++ b/src/compiler/Dialect/RelAlg/Transforms/EliminateTrivialJoin.cpp
@@ -1,0 +1,69 @@
+#include "lingodb/compiler/Dialect/RelAlg/IR/RelAlgOps.h"
+#include "lingodb/compiler/Dialect/RelAlg/IR/RelAlgOpsInterfaces.h"
+#include "lingodb/compiler/Dialect/RelAlg/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace {
+using namespace lingodb::compiler::dialect;
+
+class EliminateTrivialJoin final : public mlir::OpRewritePattern<relalg::OuterJoinOp> {
+   public:
+   using mlir::OpRewritePattern<relalg::OuterJoinOp>::OpRewritePattern;
+
+   mlir::LogicalResult matchAndRewrite(relalg::OuterJoinOp outerJoinOp, mlir::PatternRewriter& rewriter) const override {
+      bool useHash = outerJoinOp->hasAttr("useHashJoin");
+      if (!useHash) {
+         return mlir::failure();
+      }
+      auto nullsEqual = outerJoinOp->getAttrOfType<mlir::ArrayAttr>("nullsEqual");
+      for (auto nE : nullsEqual) {
+         bool nullequal = mlir::cast<mlir::IntegerAttr>(nE).getInt();
+         if (nullequal) {
+            return mlir::failure();
+         }
+      }
+
+      auto right = mlir::dyn_cast<Operator>(outerJoinOp.getRight().getDefiningOp());
+      if (!outerJoinOp->hasAttr("rightHash")) {
+         return mlir::failure();
+      }
+
+      auto rightKeysAttr = mlir::cast<mlir::ArrayAttr>(outerJoinOp->getAttrOfType<mlir::ArrayAttr>("rightHash"));
+      auto rightKeyCols = relalg::ColumnSet::fromArrayAttr(rightKeysAttr);
+
+      auto fds = right.getFDs();
+      if (!fds.isDuplicateFreeKey(rightKeyCols)) {
+         return mlir::failure();
+      }
+      if (!outerJoinOp.getMapping().empty()) {
+         return mlir::failure();
+      }
+
+      rewriter.replaceOp(outerJoinOp, outerJoinOp.getLeft());
+      return mlir::success();
+   }
+};
+
+class EliminateTrivialJoinPass
+   : public mlir::PassWrapper<EliminateTrivialJoinPass, mlir::OperationPass<mlir::func::FuncOp>> {
+   public:
+   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(EliminateTrivialJoinPass)
+   llvm::StringRef getArgument() const override { return "relalg-eliminate-outerjoin-empty-right"; }
+
+   void runOnOperation() override {
+      mlir::RewritePatternSet patterns(&getContext());
+      patterns.add<EliminateTrivialJoin>(&getContext());
+      if (mlir::applyPatternsGreedily(getOperation().getRegion(), std::move(patterns)).failed()) {
+         signalPassFailure();
+      }
+   }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> relalg::createEliminateTrivialJoinPass() {
+   return std::make_unique<EliminateTrivialJoinPass>();
+}


### PR DESCRIPTION
Fix #93 

Now there is a new optimazation pass on RelAlg that can eliminate left outer joins where the right part  do not return anything and the join keys on it are unique.

Example query (tpch):
```text
SELECT 
    l_suppkey
FROM 
    lineitem 
LEFT JOIN orders 
    ON o_orderkey = l_orderkey;
```

Optimized mlir:
```text
module {
  func.func @main() {
    %0 = relalg.query (){
      %1 = relalg.basetable  {rows = 0x4156E48FC0000000 : f64, table_identifier = "lineitem", total_rows = 0x4156E48FC0000000 : f64} columns: {l_orderkey => @lineitem::@l_orderkey({type = i32}), l_suppkey => @lineitem::@l_suppkey({type = i32})} datasource: "0000FEFF000000000000000000000000FFFF0000"
      %2 = relalg.materialize %1 [@lineitem::@l_suppkey] => ["l_suppkey"] : !subop.local_table<[l_suppkey$0 : i32], ["l_suppkey"]>
      relalg.query_return %2 : !subop.local_table<[l_suppkey$0 : i32], ["l_suppkey"]>
    } -> !subop.local_table<[l_suppkey$0 : i32], ["l_suppkey"]>
    subop.set_result 0 %0 : !subop.local_table<[l_suppkey$0 : i32], ["l_suppkey"]>
    return
  }
}
```