### PR TITLE
Issue #212: Improve vectorized IN filters (SimpleTypeInFilter, VarLen32FilterIn)

### DIFF
--- a/src/runtime/storage/Restrictions.cpp
+++ b/src/runtime/storage/Restrictions.cpp
@@ -5,6 +5,8 @@
 #include <cstddef>
 #include <cstring>
 #include <regex>
+#include <algorithm>
+#include <unordered_set>
 
 #include <arrow/table.h>
 #include <arrow/util/decimal.h>
@@ -193,28 +195,53 @@ class SimpleTypeInFilter : public lingodb::runtime::Filter {
    std::vector<T> values;
 
    public:
-   SimpleTypeInFilter(std::vector<T> values) : values(values) {}
+   SimpleTypeInFilter(std::vector<T> values) : values(values) {
+      ////We will sort the IN values to preforme binary search.
+      //The reason why we sorted values here, to avoid the overhead of sorting for every batch in filter function, 
+      //as the filter function will be called for every batch.
+      std::sort(this->values.begin(), this->values.end());
+   }
    size_t filter(size_t len, const uint16_t* currSelVec, uint16_t* nextSelVec, const lingodb::runtime::ArrayView* arrayView, size_t offset) override {
       const T* data = reinterpret_cast<const T*>(arrayView->buffers[1]) + offset + arrayView->offset;
       auto* writer = nextSelVec;
-      for (size_t i = 0; i < len; i++) {
-         size_t index0 = currSelVec[i];
-         for (auto value : values) {
-            if (value == data[index0]) {
-               *writer = index0;
-               writer++;
-               break;
+      //For small IN lists we will just do linear search,
+      //as the binary search overhead is higher than the saved comparisons
+      if (values.size() <= 10) { 
+         for (size_t i = 0; i < len; i++) {
+            size_t index0 = currSelVec[i];
+            for (auto value : values) {
+               if (value == data[index0]) {
+                  *writer = index0;
+                  writer++;
+                  break;
+               }
             }
          }
+      }
+      else {
+            for (size_t i = 0; i < len; i++) {
+               size_t index0 = currSelVec[i];
+               bool found=std::binary_search(values.begin(), values.end(), data[index0]);
+               if(found){
+                  *writer = index0;
+                  writer++;
+               }
+            }
       }
       return writer - nextSelVec;
    }
 };
 class VarLen32FilterIn : public lingodb::runtime::Filter {
    std::vector<std::string> values;
+   // for faster lookup if there are many values
+   std::unordered_set<std::string_view> valuesSet;
 
    public:
-   VarLen32FilterIn(std::vector<std::string> values) : values(values) {}
+   VarLen32FilterIn(std::vector<std::string> values) : values(values) {
+      for (const auto& s : this->values) {
+         valuesSet.insert(s);
+      }
+   }
    size_t filter(size_t len, const uint16_t* currSelVec, uint16_t* nextSelVec, const lingodb::runtime::ArrayView* arrayView, size_t offset) override {
       const uint8_t* data = reinterpret_cast<const uint8_t*>(arrayView->buffers[2]);
       const int32_t* offsets = reinterpret_cast<const int32_t*>(arrayView->buffers[1]) + offset + arrayView->offset;
@@ -224,11 +251,22 @@ class VarLen32FilterIn : public lingodb::runtime::Filter {
          int32_t offset0 = offsets[index0];
          int32_t nextOffset0 = offsets[index0 + 1];
          std::string_view strView(reinterpret_cast<const char*>(data + offset0), nextOffset0 - offset0);
-         for (const auto& s : values) {
-            if (strView == s) {
+         //We will use linear search for small IN lists,
+         //and for larger IN lists we will use an unordered_set for O(1) lookups
+         //Note: The values.size()<=10 if clause can be changed or removed after testing.
+         if(values.size() <= 10){
+            for (const auto& value : values) {
+               if (value == strView) {
+                  *writer = index0;
+                  writer++;
+                  break;
+               }
+            }
+         }
+         else{
+            if(valuesSet.find(strView) != valuesSet.end()){
                *writer = index0;
                writer++;
-               break;
             }
          }
       }
@@ -341,6 +379,8 @@ std::pair<size_t, uint16_t*> lingodb::runtime::Restrictions::applyFilters(size_t
       const lingodb::runtime::ArrayView* arrayView = getArrayView(colId);
       currentLen = filter->filter(currentLen, first ? lingodb::runtime::BatchView::defaultSelectionVector.data() : currentSelVec, nextSelVec, arrayView, offset);
       std::swap(currentSelVec, nextSelVec);
+      //early exit if no values are selected.
+      if(currentLen == 0 )return;
       assert(currentLen <= length);
       first = false;
    }

--- a/src/runtime/storage/Restrictions.cpp
+++ b/src/runtime/storage/Restrictions.cpp
@@ -253,7 +253,7 @@ class VarLen32FilterIn : public lingodb::runtime::Filter {
          std::string_view strView(reinterpret_cast<const char*>(data + offset0), nextOffset0 - offset0);
          //We will use linear search for small IN lists,
          //and for larger IN lists we will use an unordered_set for O(1) lookups
-         //Note: The values.size()<=10 if clause can be changed or removed after testing.
+         //Note: The values.size()<=10 can be changed or removed after testing.
          if(values.size() <= 10){
             for (const auto& value : values) {
                if (value == strView) {
@@ -380,7 +380,9 @@ std::pair<size_t, uint16_t*> lingodb::runtime::Restrictions::applyFilters(size_t
       currentLen = filter->filter(currentLen, first ? lingodb::runtime::BatchView::defaultSelectionVector.data() : currentSelVec, nextSelVec, arrayView, offset);
       std::swap(currentSelVec, nextSelVec);
       //early exit if no values are selected.
-      if(currentLen == 0 )return;
+       if (currentLen == 0) {
+         return {0, currentSelVec};
+      }
       assert(currentLen <= length);
       first = false;
    }

--- a/src/runtime/storage/Restrictions.cpp
+++ b/src/runtime/storage/Restrictions.cpp
@@ -2,10 +2,10 @@
 #include "lingodb/runtime/ArrowView.h"
 #include "lingodb/utility/Tracer.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstring>
 #include <regex>
-#include <algorithm>
 #include <unordered_set>
 
 #include <arrow/table.h>
@@ -197,7 +197,7 @@ class SimpleTypeInFilter : public lingodb::runtime::Filter {
    public:
    SimpleTypeInFilter(std::vector<T> values) : values(values) {
       ////We will sort the IN values to preforme binary search.
-      //The reason why we sorted values here, to avoid the overhead of sorting for every batch in filter function, 
+      //The reason why we sorted values here, to avoid the overhead of sorting for every batch in filter function,
       //as the filter function will be called for every batch.
       std::sort(this->values.begin(), this->values.end());
    }
@@ -206,7 +206,7 @@ class SimpleTypeInFilter : public lingodb::runtime::Filter {
       auto* writer = nextSelVec;
       //For small IN lists we will just do linear search,
       //as the binary search overhead is higher than the saved comparisons
-      if (values.size() <= 10) { 
+      if (values.size() <= 10) {
          for (size_t i = 0; i < len; i++) {
             size_t index0 = currSelVec[i];
             for (auto value : values) {
@@ -217,16 +217,15 @@ class SimpleTypeInFilter : public lingodb::runtime::Filter {
                }
             }
          }
-      }
-      else {
-            for (size_t i = 0; i < len; i++) {
-               size_t index0 = currSelVec[i];
-               bool found=std::binary_search(values.begin(), values.end(), data[index0]);
-               if(found){
-                  *writer = index0;
-                  writer++;
-               }
+      } else {
+         for (size_t i = 0; i < len; i++) {
+            size_t index0 = currSelVec[i];
+            bool found = std::binary_search(values.begin(), values.end(), data[index0]);
+            if (found) {
+               *writer = index0;
+               writer++;
             }
+         }
       }
       return writer - nextSelVec;
    }
@@ -254,7 +253,7 @@ class VarLen32FilterIn : public lingodb::runtime::Filter {
          //We will use linear search for small IN lists,
          //and for larger IN lists we will use an unordered_set for O(1) lookups
          //Note: The values.size()<=10 can be changed or removed after testing.
-         if(values.size() <= 10){
+         if (values.size() <= 10) {
             for (const auto& value : values) {
                if (value == strView) {
                   *writer = index0;
@@ -262,9 +261,8 @@ class VarLen32FilterIn : public lingodb::runtime::Filter {
                   break;
                }
             }
-         }
-         else{
-            if(valuesSet.find(strView) != valuesSet.end()){
+         } else {
+            if (valuesSet.find(strView) != valuesSet.end()) {
                *writer = index0;
                writer++;
             }
@@ -380,7 +378,7 @@ std::pair<size_t, uint16_t*> lingodb::runtime::Restrictions::applyFilters(size_t
       currentLen = filter->filter(currentLen, first ? lingodb::runtime::BatchView::defaultSelectionVector.data() : currentSelVec, nextSelVec, arrayView, offset);
       std::swap(currentSelVec, nextSelVec);
       //early exit if no values are selected.
-       if (currentLen == 0) {
+      if (currentLen == 0) {
          return {0, currentSelVec};
       }
       assert(currentLen <= length);


### PR DESCRIPTION
Summary:
This PR partially addresses issue #212 by improving lookup strategies in two vectorized IN filters:
1. SimpleTypeInFilter
2. VarLen32FilterIn

What changed:
1) SimpleTypeInFilter:
Added preprocessing step to sort IN values once in the constructor.
Replaced nested loop membership checks with adaptive lookup:
small IN list: linear scan
larger IN list: binary search on the sorted values
Why: Old behavior was effectively O(N * M) (rows × IN-list length).
New behavior for larger lists is O(N * log M), with one time O(M log M) preprocessing.

2) VarLen32FilterIn:
Added adaptive lookup strategy for string IN values:
small IN list: linear scan
larger IN list: hash-based lookup using unordered_set data structure
Why: Avoid repeated full scans of IN values for each row.
Improves expected lookup from O(M) per row to O(1) average for larger lists.

Correctness:
Filter semantics are unchanged; only membership lookup implementation is optimized.

Validation status:
No benchmark results yet.
Performance claims are based on algorithmic complexity and should be confirmed with follow-up microbenchmarks.