### PR TITLE
arrow dialect: drop interval_daytime ops, move handling to db lowering

### DIFF
--- a/include/lingodb/compiler/Dialect/Arrow/IR/ArrowBase.td
+++ b/include/lingodb/compiler/Dialect/Arrow/IR/ArrowBase.td
@@ -18,9 +18,13 @@ def Arrow_Dialect : Dialect {
         The Arrow dialect provides types and operations for working with Apache Arrow data structures.
         It includes types for arrays and builders (for chunked arrays), and the necessary operations to load values from arrays, and append values to builders.
 
-        The operation implemented by this dialect work directly on the physical memory layout, and do not have any knowledge about Apache Arrow's logical types.
+        The operations implemented by this dialect work directly on the *physical* memory layout, and do not have any knowledge about Apache Arrow's logical types.
         For example, dates are loaded as integers, strings are loaded as ptr + len, and so on.
-        Dealing with logical types is the responsibility of higher-level dialects.
+        Do **not** add operations or lowerings here that encode logical-type semantics
+        (e.g. interval_day_time -> nanoseconds, decimal scaling, timestamp unit conversion).
+        Such logical-to-physical translation is the responsibility of higher-level dialects
+        (in particular the DB dialect, see `Conversion/DBToStd/LowerToStd.cpp`), which
+        emit the appropriate sequence of physical loads/appends defined here.
     }];
     let cppNamespace = "::lingodb::compiler::dialect::arrow";
     let extraClassDeclaration = [{

--- a/include/lingodb/compiler/Dialect/Arrow/IR/ArrowOps.td
+++ b/include/lingodb/compiler/Dialect/Arrow/IR/ArrowOps.td
@@ -50,12 +50,6 @@ def Arrow_LoadVariableSizeBinaryOp : Arrow_Op<"array.load_variable_size_binary",
     let results = (outs I32:$length, RefType : $ptr);
     let assemblyFormat = " $array `,` $offset `->` type($ptr) attr-dict";
 }
-def Arrow_LoadIntervalDaytimeOp : Arrow_Op<"array.load_interval_daytime", [Pure] > {
-    let summary = "Loads an interval_day_time value from an array and returns nanoseconds.";
-    let arguments = (ins Arrow_Array:$array,Index:$offset);
-    let results = (outs I64:$value);
-    let assemblyFormat = " $array `,` $offset attr-dict";
-}
 def Arrow_AppendBoolOp : Arrow_Op<"array_builder.append_bool"> {
     let summary = "Appends a boolean value to an Arrow array builder.";
     let description = [{
@@ -73,11 +67,6 @@ def Arrow_AppendFixedSizedOp : Arrow_Op<"array_builder.append_fixed_sized"> {
     }];
     let arguments = (ins Arrow_ArrayBuilder:$builder, AnyType: $value, Optional<I1>: $valid);
     let assemblyFormat = " $builder `,` $value `:` type($value) ( `,` $valid^ )? attr-dict";
-}
-def Arrow_AppendIntervalDaytimeOp : Arrow_Op<"array_builder.append_interval_daytime"> {
-    let summary = "Appends an interval<daytime> value (nanoseconds) to an Arrow array builder (endianness-stable).";
-    let arguments = (ins Arrow_ArrayBuilder:$builder, I64: $nanos, Optional<I1>: $valid);
-    let assemblyFormat = " $builder `,` $nanos ( `,` $valid^ )? attr-dict";
 }
 def Arrow_AppendVariableSizeBinaryOp : Arrow_Op<"array_builder.append_variable_sized_binary"> {
     let summary = "Appends a variable sized binary value to an Arrow array builder.";

--- a/src/compiler/Conversion/ArrowToStd/ArrowToStd.cpp
+++ b/src/compiler/Conversion/ArrowToStd/ArrowToStd.cpp
@@ -103,46 +103,6 @@ static Value getBit(OpBuilder builder, Location loc, Value bits, Value pos) {
    return res;
 }
 
-class ArrayLoadIntervalDaytimeLowering : public OpConversionPattern<arrow::LoadIntervalDaytimeOp> {
-   public:
-   using OpConversionPattern<arrow::LoadIntervalDaytimeOp>::OpConversionPattern;
-   LogicalResult matchAndRewrite(arrow::LoadIntervalDaytimeOp op, OpAdaptor adaptor, ConversionPatternRewriter& rewriter) const override {
-      auto loc = op.getLoc();
-      auto idxType = rewriter.getIndexType();
-      auto i64Type = rewriter.getI64Type();
-      auto i32Type = rewriter.getI32Type();
-      mlir::Value valueBytes;
-      mlir::Value arrayOffset;
-      createAtArrayCreation(rewriter, adaptor.getArray(), [&](mlir::ConversionPatternRewriter& rewriter) {
-         arrayOffset = rewriter.create<util::LoadElementOp>(loc, idxType, adaptor.getArray(), 2);
-         auto bufferArray = rewriter.create<util::LoadElementOp>(loc, util::RefType::get(util::RefType::get(rewriter.getI8Type())), adaptor.getArray(), 5);
-         auto c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-         valueBytes = rewriter.create<util::LoadOp>(loc, bufferArray, c1);
-      });
-
-      Value i32Buffer = rewriter.create<util::GenericMemrefCastOp>(loc, util::RefType::get(i32Type), valueBytes);
-      Value elementIndex = rewriter.create<arith::AddIOp>(loc, idxType, arrayOffset, adaptor.getOffset());
-      Value c2 = rewriter.create<arith::ConstantIndexOp>(loc, 2);
-      Value i32BaseIndex = rewriter.create<arith::MulIOp>(loc, idxType, elementIndex, c2);
-      Value dayMsBase = rewriter.create<util::ArrayElementPtrOp>(loc, util::RefType::get(i32Type), i32Buffer, i32BaseIndex);
-      Value daysI32 = rewriter.create<util::LoadOp>(loc, dayMsBase);
-      Value c1 = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-      Value msPtr = rewriter.create<util::ArrayElementPtrOp>(loc, util::RefType::get(i32Type), dayMsBase, c1);
-      Value msI32 = rewriter.create<util::LoadOp>(loc, msPtr);
-
-      Value daysI64 = rewriter.create<arith::ExtSIOp>(loc, i64Type, daysI32);
-      Value msI64 = rewriter.create<arith::ExtSIOp>(loc, i64Type, msI32);
-
-      Value nanosPerDay = rewriter.create<arith::ConstantIntOp>(loc, 86400000000000ll, 64);
-      Value nanosPerMilli = rewriter.create<arith::ConstantIntOp>(loc, 1000000ll, 64);
-      Value dayNanos = rewriter.create<arith::MulIOp>(loc, i64Type, daysI64, nanosPerDay);
-      Value msNanos = rewriter.create<arith::MulIOp>(loc, i64Type, msI64, nanosPerMilli);
-      Value nanos = rewriter.create<arith::AddIOp>(loc, i64Type, dayNanos, msNanos);
-
-      rewriter.replaceOp(op, nanos);
-      return success();
-   }
-};
 class ArrayLoadBoolLowering : public OpConversionPattern<arrow::LoadBoolOp> {
    public:
    using OpConversionPattern<arrow::LoadBoolOp>::OpConversionPattern;
@@ -283,44 +243,6 @@ class BuilderAppendVariableSizeBinaryLowering : public OpConversionPattern<arrow
    }
 };
 
-class BuilderAppendIntervalDaytimeLowering : public OpConversionPattern<arrow::AppendIntervalDaytimeOp> {
-   public:
-   using OpConversionPattern<arrow::AppendIntervalDaytimeOp>::OpConversionPattern;
-   LogicalResult matchAndRewrite(arrow::AppendIntervalDaytimeOp op, OpAdaptor adaptor, ConversionPatternRewriter& rewriter) const override {
-      auto loc = op.getLoc();
-      auto builderVal = adaptor.getBuilder();
-      auto isValid = adaptor.getValid();
-      if (!isValid) {
-         isValid = rewriter.create<mlir::arith::ConstantIntOp>(loc, 1, 1);
-      }
-      auto nanos = adaptor.getNanos();
-      auto i64Type = rewriter.getI64Type();
-      auto i32Type = rewriter.getI32Type();
-      Value nanosPerDay = rewriter.create<arith::ConstantIntOp>(loc, 86400000000000ll, 64);
-      Value nanosPerMilli = rewriter.create<arith::ConstantIntOp>(loc, 1000000ll, 64);
-      Value daysI64 = rewriter.create<arith::DivSIOp>(loc, i64Type, nanos, nanosPerDay);
-      Value rem = rewriter.create<arith::RemSIOp>(loc, i64Type, nanos, nanosPerDay);
-      Value millisI64 = rewriter.create<arith::DivSIOp>(loc, i64Type, rem, nanosPerMilli);
-      Value daysI32 = rewriter.create<arith::TruncIOp>(loc, i32Type, daysI64);
-      Value millisI32 = rewriter.create<arith::TruncIOp>(loc, i32Type, millisI64);
-
-      auto tupleType = mlir::TupleType::get(rewriter.getContext(), {i32Type, i32Type});
-      auto funcParent = op->getParentOfType<func::FuncOp>();
-      mlir::Value stackSlot;
-      {
-         mlir::OpBuilder::InsertionGuard guard(rewriter);
-         rewriter.setInsertionPointToStart(&funcParent.getBody().front());
-         stackSlot = rewriter.create<util::AllocaOp>(loc, util::RefType::get(tupleType), mlir::Value{});
-      }
-      Value daysPtr = rewriter.create<util::TupleElementPtrOp>(loc, util::RefType::get(i32Type), stackSlot, rewriter.getI32IntegerAttr(0));
-      Value millisPtr = rewriter.create<util::TupleElementPtrOp>(loc, util::RefType::get(i32Type), stackSlot, rewriter.getI32IntegerAttr(1));
-      rewriter.create<util::StoreOp>(loc, daysI32, daysPtr, mlir::Value{});
-      rewriter.create<util::StoreOp>(loc, millisI32, millisPtr, mlir::Value{});
-      rt::ArrowColumnBuilder::addFixedSized(rewriter, loc)({builderVal, isValid, stackSlot});
-      rewriter.eraseOp(op);
-      return success();
-   }
-};
 } // end anonymous namespace
 template <class Op>
 class SimpleTypeConversionPattern : public ConversionPattern {
@@ -413,12 +335,10 @@ void ArrowToStdLoweringPass::runOnOperation() {
    patterns.insert<ArrayLoadFixedSizedLowering>(typeConverter, &getContext());
    patterns.insert<ArrayLoadVariableSizeBinaryLowering>(typeConverter, &getContext());
    patterns.insert<ArrayLoadBoolLowering>(typeConverter, &getContext());
-   patterns.insert<ArrayLoadIntervalDaytimeLowering>(typeConverter, &getContext());
    patterns.insert<BuilderFromPtrLowering>(typeConverter, &getContext());
    patterns.insert<BuilderAppendFixedSizedLowering>(typeConverter, &getContext());
    patterns.insert<BuilderAppendBoolLowering>(typeConverter, &getContext());
    patterns.insert<BuilderAppendVariableSizeBinaryLowering>(typeConverter, &getContext());
-   patterns.insert<BuilderAppendIntervalDaytimeLowering>(typeConverter, &getContext());
    if (failed(applyFullConversion(module, target, std::move(patterns))))
       signalPassFailure();
 }

--- a/src/compiler/Conversion/DBToStd/LowerToStd.cpp
+++ b/src/compiler/Conversion/DBToStd/LowerToStd.cpp
@@ -170,7 +170,25 @@ class LoadArrowOpLowering : public OpConversionPattern<db::LoadArrowOp> {
          if (intervalType.getUnit() == db::IntervalUnitAttr::months) {
             loaded = rewriter.create<lingodb::compiler::dialect::arrow::LoadFixedSizedOp>(loc, rewriter.getI32Type(), array, offset);
          } else {
-            loaded = rewriter.create<lingodb::compiler::dialect::arrow::LoadIntervalDaytimeOp>(loc, array, offset);
+            // Arrow's interval_day_time is two i32s (days, milliseconds) packed
+            // into 8 bytes. Load the whole 8 bytes as one i64 so the per-element
+            // stride matches the logical Arrow element, then split here in the
+            // DB lowering (low 32 = days, high 32 = ms; little-endian). The
+            // arrow dialect itself stays oblivious to the logical type.
+            auto i32Type = rewriter.getI32Type();
+            auto i64Type = rewriter.getI64Type();
+            mlir::Value packed = rewriter.create<lingodb::compiler::dialect::arrow::LoadFixedSizedOp>(loc, i64Type, array, offset);
+            mlir::Value c32 = rewriter.create<arith::ConstantIntOp>(loc, 32, 64);
+            mlir::Value daysI32 = rewriter.create<arith::TruncIOp>(loc, i32Type, packed);
+            mlir::Value msShifted = rewriter.create<arith::ShRUIOp>(loc, i64Type, packed, c32);
+            mlir::Value msI32 = rewriter.create<arith::TruncIOp>(loc, i32Type, msShifted);
+            mlir::Value daysI64 = rewriter.create<arith::ExtSIOp>(loc, i64Type, daysI32);
+            mlir::Value msI64 = rewriter.create<arith::ExtSIOp>(loc, i64Type, msI32);
+            mlir::Value nanosPerDay = rewriter.create<arith::ConstantIntOp>(loc, 86400000000000ll, 64);
+            mlir::Value nanosPerMilli = rewriter.create<arith::ConstantIntOp>(loc, 1000000ll, 64);
+            mlir::Value dayNanos = rewriter.create<arith::MulIOp>(loc, i64Type, daysI64, nanosPerDay);
+            mlir::Value msNanos = rewriter.create<arith::MulIOp>(loc, i64Type, msI64, nanosPerMilli);
+            loaded = rewriter.create<arith::AddIOp>(loc, i64Type, dayNanos, msNanos);
          }
       } else {
          return mlir::failure();
@@ -241,7 +259,25 @@ class AppendArrowLowering : public OpConversionPattern<db::AppendArrowOp> {
          if (intervalType.getUnit() == db::IntervalUnitAttr::months) {
             rewriter.create<lingodb::compiler::dialect::arrow::AppendFixedSizedOp>(loc, builder, value, valid);
          } else {
-            rewriter.create<lingodb::compiler::dialect::arrow::AppendIntervalDaytimeOp>(loc, builder, value, valid);
+            // Mirror of the load above: split nanoseconds into (days, ms) i32
+            // pair and pack into one i64 with days in the low 32 bits and ms
+            // in the high 32 bits (little-endian). The arrow dialect just
+            // appends 8 bytes of fixed-sized payload.
+            auto i32Type = rewriter.getI32Type();
+            auto i64Type = rewriter.getI64Type();
+            mlir::Value nanosPerDay = rewriter.create<arith::ConstantIntOp>(loc, 86400000000000ll, 64);
+            mlir::Value nanosPerMilli = rewriter.create<arith::ConstantIntOp>(loc, 1000000ll, 64);
+            mlir::Value daysI64 = rewriter.create<arith::DivSIOp>(loc, i64Type, value, nanosPerDay);
+            mlir::Value rem = rewriter.create<arith::RemSIOp>(loc, i64Type, value, nanosPerDay);
+            mlir::Value msI64 = rewriter.create<arith::DivSIOp>(loc, i64Type, rem, nanosPerMilli);
+            mlir::Value daysI32 = rewriter.create<arith::TruncIOp>(loc, i32Type, daysI64);
+            mlir::Value msI32 = rewriter.create<arith::TruncIOp>(loc, i32Type, msI64);
+            mlir::Value daysExt = rewriter.create<arith::ExtUIOp>(loc, i64Type, daysI32);
+            mlir::Value msExt = rewriter.create<arith::ExtUIOp>(loc, i64Type, msI32);
+            mlir::Value c32 = rewriter.create<arith::ConstantIntOp>(loc, 32, 64);
+            mlir::Value msShifted = rewriter.create<arith::ShLIOp>(loc, i64Type, msExt, c32);
+            mlir::Value packed = rewriter.create<arith::OrIOp>(loc, i64Type, daysExt, msShifted);
+            rewriter.create<lingodb::compiler::dialect::arrow::AppendFixedSizedOp>(loc, builder, packed, valid);
          }
       } else if (mlir::isa<db::StringType>(baseType)) {
          rewriter.create<lingodb::compiler::dialect::arrow::AppendVariableSizeBinaryOp>(loc, builder, value, valid);


### PR DESCRIPTION
The arrow dialect should expose only Arrow's physical layout; logical-type semantics (here: interval_day_time -> nanoseconds) belong in the DB->Std lowering. Remove arrow.array.load_interval_daytime and arrow.array_builder.append_interval_daytime plus their lowerings, and inline the equivalent pack/unpack into LoadArrowOpLowering / AppendArrowLowering by treating the 8-byte daytime element as a single i64 (low 32 = days, high 32 = ms on little-endian). Reinforce the rule in the dialect-level description.