### PR TITLE
Fix out-of-bounds read in FirstNotNullFilter vectorized loop

### DIFF
--- a/src/runtime/storage/Restrictions.cpp
+++ b/src/runtime/storage/Restrictions.cpp
@@ -83,8 +83,9 @@ class FirstNotNullFilter : public lingodb::runtime::Filter {
          writer += (bool) ((validData[index0 / 8] >> (index0 % 8)) & 1);
       }
       assert((i + offset + arrayView->offset) % 8 == 0 || i == len);
-      size_t len8 = len & ~7;
-      for (; i < len8; i += 8) {
+      // Process whole-byte chunks; stop when fewer than 8 elements remain so the
+      // i+7 reads inside the loop body never run past the unit boundary.
+      for (; i + 8 <= len; i += 8) {
          uint8_t byte = validData[(i + offset + arrayView->offset) / 8];
          *writer = i;
          writer += (bool) (byte & 1);


### PR DESCRIPTION
## Summary

- `FirstNotNullFilter::filter` aligns its starting `i` to a byte boundary (a 0..7 shift) before entering the 8-wide vectorized loop, but the loop bound was `i < (len & ~7)` — written assuming `i` started at 0. Once alignment moved `i` past zero, the last vectorized iteration's `i+1..i+7` reads ran past the unit boundary, and the writes also ran past the end of the splitSize-sized scratch selection vector. The phantom selection-vector entry was then consumed by whatever filter ran next, occasionally producing a duplicate row.
- Surfaced as wrong results on TPC-DS Q30 at high core counts (small `splitSize` ⇒ multiple units per batch ⇒ non-zero alignment shifts). On 4-vCPU CI runners `splitSize` is large enough that each batch is one unit, alignment is 0, and the loop bound is incidentally correct — which is why CI didn't catch it.
- Fix: switch the loop bound to `i + 8 <= len`, which keeps all 8 indices touched per iteration in-range regardless of the alignment shift.
- The other vectorized filters in this file (`NotNullFilter`, `SimpleTypeFilter`, `VarLen32Filter`) all enter their loops with `i = 0` and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)