### PR TITLE
Select null fix

### DIFF
--- a/include/lingodb/compiler/Dialect/Arrow/IR/ArrowOps.td
+++ b/include/lingodb/compiler/Dialect/Arrow/IR/ArrowOps.td
@@ -68,6 +68,17 @@ def Arrow_AppendFixedSizedOp : Arrow_Op<"array_builder.append_fixed_sized"> {
     let arguments = (ins Arrow_ArrayBuilder:$builder, AnyType: $value, Optional<I1>: $valid);
     let assemblyFormat = " $builder `,` $value `:` type($value) ( `,` $valid^ )? attr-dict";
 }
+
+def Arrow_AppendNullOp : Arrow_Op<"array_builder.append_null"> {
+    let summary = "Appends a fixed sized value to an Arrow array builder.";
+    let description = [{
+        This operation appends a fixed sized value to an Arrow array builder, optionally with a validity flag.
+        It can be used for any fixed sized type, such as integers, floats, decimals, dates, and timestamps.
+    }];
+    let arguments = (ins Arrow_ArrayBuilder:$builder);
+    let assemblyFormat = " $builder attr-dict";
+}
+
 def Arrow_AppendVariableSizeBinaryOp : Arrow_Op<"array_builder.append_variable_sized_binary"> {
     let summary = "Appends a variable sized binary value to an Arrow array builder.";
     let description = [{

--- a/include/lingodb/compiler/Dialect/Arrow/IR/ArrowOps.td
+++ b/include/lingodb/compiler/Dialect/Arrow/IR/ArrowOps.td
@@ -70,10 +70,10 @@ def Arrow_AppendFixedSizedOp : Arrow_Op<"array_builder.append_fixed_sized"> {
 }
 
 def Arrow_AppendNullOp : Arrow_Op<"array_builder.append_null"> {
-    let summary = "Appends a fixed sized value to an Arrow array builder.";
+    let summary = "Appends a null value to an Arrow array builder.";
     let description = [{
-        This operation appends a fixed sized value to an Arrow array builder, optionally with a validity flag.
-        It can be used for any fixed sized type, such as integers, floats, decimals, dates, and timestamps.
+        This operation appends a null/none value to an Arrow array builder.
+
     }];
     let arguments = (ins Arrow_ArrayBuilder:$builder);
     let assemblyFormat = " $builder attr-dict";

--- a/include/lingodb/runtime/ArrowColumn.h
+++ b/include/lingodb/runtime/ArrowColumn.h
@@ -28,6 +28,7 @@ class ArrowColumnBuilder {
    ArrowColumnBuilder* getChildBuilder();
    void addBool(bool isValid, bool value);
    void addFixedSized(bool isValid, uint8_t* value);
+   void addNull();
 
    void addList(bool isValid);
    void addBinary(bool isValid, runtime::VarLen32);

--- a/src/compiler/Conversion/ArrowToStd/ArrowToStd.cpp
+++ b/src/compiler/Conversion/ArrowToStd/ArrowToStd.cpp
@@ -207,6 +207,21 @@ class BuilderAppendFixedSizedLowering : public OpConversionPattern<arrow::Append
       return success();
    }
 };
+
+class BuilderAppendNullLowering : public OpConversionPattern<arrow::AppendNullOp> {
+   public:
+   using OpConversionPattern<arrow::AppendNullOp>::OpConversionPattern;
+   LogicalResult matchAndRewrite(arrow::AppendNullOp op, OpAdaptor adaptor, ConversionPatternRewriter& rewriter) const override {
+      auto loc = op.getLoc();
+      auto builderVal = adaptor.getBuilder();
+
+      rt::ArrowColumnBuilder::addNull(rewriter, loc)({builderVal});
+      rewriter.eraseOp(op);
+
+      return success();
+   }
+};
+
 class BuilderAppendBoolLowering : public OpConversionPattern<arrow::AppendBoolOp> {
    public:
    using OpConversionPattern<arrow::AppendBoolOp>::OpConversionPattern;
@@ -339,6 +354,7 @@ void ArrowToStdLoweringPass::runOnOperation() {
    patterns.insert<ArrayLoadBoolLowering>(typeConverter, &getContext());
    patterns.insert<BuilderFromPtrLowering>(typeConverter, &getContext());
    patterns.insert<BuilderAppendFixedSizedLowering>(typeConverter, &getContext());
+   patterns.insert<BuilderAppendNullLowering>(typeConverter, &getContext());
    patterns.insert<BuilderAppendBoolLowering>(typeConverter, &getContext());
    patterns.insert<BuilderAppendVariableSizeBinaryLowering>(typeConverter, &getContext());
    if (failed(applyFullConversion(module, target, std::move(patterns))))

--- a/src/compiler/Conversion/DBToStd/LowerToStd.cpp
+++ b/src/compiler/Conversion/DBToStd/LowerToStd.cpp
@@ -289,7 +289,11 @@ class AppendArrowLowering : public OpConversionPattern<db::AppendArrowOp> {
          } else {
             rewriter.create<lingodb::compiler::dialect::arrow::AppendVariableSizeBinaryOp>(loc, builder, value, valid);
          }
-      } else {
+      } else if (auto noneType = mlir::dyn_cast_or_null<NoneType>(baseType)) {
+         rewriter.create<lingodb::compiler::dialect::arrow::AppendNullOp>(loc, builder);
+      }
+
+      else {
          return failure();
       }
       rewriter.eraseOp(appendArrowOp);

--- a/src/compiler/Conversion/SubOpToControlFlow/SubOpToControlFlow.cpp
+++ b/src/compiler/Conversion/SubOpToControlFlow/SubOpToControlFlow.cpp
@@ -1299,6 +1299,8 @@ class CreateTableLowering : public SubOpConversionPattern<subop::GenericCreateOp
          } else {
             return "string";
          }
+      } else if (auto noneType = mlir::dyn_cast_or_null<NoneType>(type)) {
+         return "null";
       }
       assert(false);
       return "";

--- a/src/compiler/frontend/sql_analyzer.cpp
+++ b/src/compiler/frontend/sql_analyzer.cpp
@@ -1055,13 +1055,14 @@ std::shared_ptr<ast::TableProducer> SQLQueryAnalyzer::analyzePipeOperator(std::s
                case ast::ExpressionClass::BOUND_STAR: {
                   auto star = std::static_pointer_cast<ast::BoundStarExpression>(parsedExpression);
                   targetColumns.resize(star->columnReferences.size());
-                  context->currentScope->targetInfo.resize(star->columnReferences.size());
+                  auto oldSize = context->currentScope->targetInfo.size();
+                  context->currentScope->targetInfo.resize(oldSize + star->columnReferences.size());
                   std::vector<catalog::Catalog> catalogs;
                   std::string scope;
                   std::vector<catalog::Column> columns;
                   for (auto& [columnReference, index] : star->columnReferences) {
                      targetColumns[index] = columnReference;
-                     context->currentScope->targetInfo[(index)] = columnReference;
+                     context->currentScope->targetInfo[(index) + oldSize] = columnReference;
                   }
 
                   break;

--- a/src/execution/ResultProcessor.cpp
+++ b/src/execution/ResultProcessor.cpp
@@ -8,6 +8,7 @@
 #include "lingodb/execution/ResultProcessing.h"
 #include "lingodb/runtime/ArrowTable.h"
 #include <functional>
+#include <arrow/array/array_base.h>
 
 namespace {
 unsigned char hexval(unsigned char c) {
@@ -54,7 +55,27 @@ void printTable(const std::shared_ptr<arrow::Table>& table) {
       convertHex.push_back(table->schema()->field(positions.size())->type()->id() == arrow::Type::FIXED_SIZE_BINARY);
       rowSep += std::string(33, '-');
       std::string str;
-      arrow::PrettyPrint(*c.get(), options, &str); //NOLINT (clang-diagnostic-unused-result)
+      // --- Handle NULL values differently ---
+      if (table->schema()->field(positions.size())->type()->id() == arrow::Type::NA) {
+         std::stringstream nullRep;
+         nullRep << "[\n"; // Outer ChunkedArray bracket
+         for (int i = 0; i < c->num_chunks(); ++i) {
+            nullRep << "[\n"; // Inner Array chunk bracket
+            auto chunk = c->chunk(i);
+            for (int64_t j = 0; j < chunk->null_count(); ++j) {
+               nullRep << "null";
+               if (j < chunk->length() - 1) nullRep << ",\n";
+               else nullRep << "\n";
+            }
+            nullRep << "]"; // Close inner Array chunk
+            if (i < c->num_chunks() - 1) nullRep << ",\n";
+            else nullRep << "\n";
+         }
+         nullRep << "]"; // Close outer ChunkedArray
+         str = nullRep.str();
+      } else {
+         arrow::PrettyPrint(*c.get(), options, &str); //NOLINT (clang-diagnostic-unused-result)
+      }
       columnReps.push_back(str);
       positions.push_back(0);
    }

--- a/src/execution/ResultProcessor.cpp
+++ b/src/execution/ResultProcessor.cpp
@@ -7,7 +7,6 @@
 
 #include "lingodb/execution/ResultProcessing.h"
 #include "lingodb/runtime/ArrowTable.h"
-#include <functional>
 #include <arrow/array/array_base.h>
 
 namespace {
@@ -64,12 +63,16 @@ void printTable(const std::shared_ptr<arrow::Table>& table) {
             auto chunk = c->chunk(i);
             for (int64_t j = 0; j < chunk->null_count(); ++j) {
                nullRep << "null";
-               if (j < chunk->length() - 1) nullRep << ",\n";
-               else nullRep << "\n";
+               if (j < chunk->length() - 1)
+                  nullRep << ",\n";
+               else
+                  nullRep << "\n";
             }
             nullRep << "]"; // Close inner Array chunk
-            if (i < c->num_chunks() - 1) nullRep << ",\n";
-            else nullRep << "\n";
+            if (i < c->num_chunks() - 1)
+               nullRep << ",\n";
+            else
+               nullRep << "\n";
          }
          nullRep << "]"; // Close outer ChunkedArray
          str = nullRep.str();

--- a/src/runtime/ArrowColumn.cpp
+++ b/src/runtime/ArrowColumn.cpp
@@ -63,6 +63,8 @@ std::shared_ptr<arrow::DataType> createType(std::string name, uint32_t p1, uint3
       return arrow::decimal128(p1, p2);
    } else if (name == "bool") {
       return arrow::boolean();
+   } else if (name == "null") {
+      return arrow::null();
    }
    throw std::runtime_error("unknown type");
 }
@@ -159,6 +161,11 @@ void ArrowColumnBuilder::addFixedSized(bool isValid, uint8_t* value) {
    } else {
       handleStatus(typedBuilder->Append(value));
    }
+}
+
+void ArrowColumnBuilder::addNull() {
+   next();
+   handleStatus(builder->AppendNull());
 }
 
 void ArrowColumnBuilder::addBinary(bool isValid, lingodb::runtime::VarLen32 string) {

--- a/test/sqlite-small/uni.test
+++ b/test/sqlite-small/uni.test
@@ -473,6 +473,11 @@ select * from studenten s
 24002	Xenokrates	18
 25403	Jonas	12
 
+query
+select null
+----
+1 nulls
+
 #Explicitly expecting a error from the parser or analyzer
 statement frontend-error: No Catalog found with name
 select * from student s


### PR DESCRIPTION
This PR fixes #285.

It also includes a fix for queries such as `SELECT c1, *`, where the explicitly selected column (`c1`) was previously ignored due to the `*`.