### PR TITLE
Split large single-threaded scan batches

### DIFF
--- a/src/runtime/storage/LingoDBTable.cpp
+++ b/src/runtime/storage/LingoDBTable.cpp
@@ -508,7 +508,7 @@ class ScanBatchesSingleThreadedTask : public lingodb::scheduler::TaskWithImplici
       for (auto& batch : batches) {
          utility::Tracer::Trace trace(processMorselSingle);
          for (size_t start = 0; start < batch.getNumRows(); start += BatchView::maxBatchSize) {
-            size_t len = batch.getNumRows() - start;
+            size_t len = std::min(BatchView::maxBatchSize, batch.getNumRows() - start);
             batchView.offset = start;
             batchView.length = len;
             for (size_t i = 0; i < colIds.size(); i++) {

--- a/test/unittests/storage/TestStorage.cpp
+++ b/test/unittests/storage/TestStorage.cpp
@@ -11,11 +11,13 @@
 #include "lingodb/runtime/RelationHelper.h"
 #include "lingodb/runtime/Session.h"
 #include "lingodb/runtime/storage/Index.h"
+#include "lingodb/runtime/storage/LingoDBTable.h"
 #include "lingodb/runtime/storage/TableStorage.h"
 #include "lingodb/scheduler/Tasks.h"
 #include "lingodb/utility/Serialization.h"
 
 #include <filesystem>
+#include <numeric>
 
 #include <arrow/builder.h>
 #include <arrow/ipc/reader.h>
@@ -231,6 +233,35 @@ class MockTaskWithContext : public lingodb::scheduler::TaskWithContext {
 };
 
 } // namespace
+
+TEST_CASE("Storage:SingleThreadedScanSplitsLargeBatches") {
+   auto scheduler = lingodb::scheduler::startScheduler();
+
+   auto schema = arrow::schema({arrow::field("value", arrow::int32())});
+   std::vector<int32_t> values(lingodb::runtime::BatchView::maxBatchSize + 1);
+   std::iota(values.begin(), values.end(), 0);
+
+   arrow::Int32Builder builder;
+   REQUIRE(builder.AppendValues(values).ok());
+   auto column = builder.Finish().ValueOrDie();
+
+   lingodb::runtime::LingoDBTable table("", schema);
+   table.append({arrow::RecordBatch::Make(schema, values.size(), {column})});
+
+   std::vector<size_t> batchLengths;
+   lingodb::runtime::ScanConfig scanConfig{
+      .parallel = false,
+      .columns = {"value"},
+      .filters = {{.columnName = "value", .columnId = 0, .op = lingodb::runtime::FilterOp::GTE,
+                   .value = int64_t{0}, .values = std::vector<int64_t>{}}},
+      .cb = [&](lingodb::runtime::BatchView* batchView) {
+         batchLengths.push_back(batchView->length);
+      },
+   };
+   lingodb::scheduler::awaitEntryTask(table.createScanTask(scanConfig));
+
+   REQUIRE(batchLengths == std::vector<size_t>{lingodb::runtime::BatchView::maxBatchSize, 1});
+}
 
 TEST_CASE("Storage") {
    auto scheduler = lingodb::scheduler::startScheduler();


### PR DESCRIPTION
## What changed
Cap each single-threaded scan morsel at `BatchView::maxBatchSize`, matching the selection-vector allocation and the parallel scan path. Add a regression test with a 65,537-row Arrow record batch and a pushed-down filter.

## Root cause
The loop advanced `start` in `BatchView::maxBatchSize` chunks but passed the entire remaining record batch as `len`. For a record batch larger than 65,536 rows, a filtered scan could assert in debug builds or write past its 65,536-entry selection buffers in release builds.

## Validation
- Ran `git diff --check`
- Added a focused Catch2 regression test
- Local container test could not run because the Docker daemon is unavailable on this machine; project CI should exercise the test on macOS and Linux.