### PR TITLE
Support NULL-only result columns

### DIFF
--- a/include/lingodb/compiler/Dialect/Arrow/IR/ArrowOps.td
+++ b/include/lingodb/compiler/Dialect/Arrow/IR/ArrowOps.td
@@ -79,6 +79,12 @@ def Arrow_AppendVariableSizeBinaryOp : Arrow_Op<"array_builder.append_variable_s
     let assemblyFormat = " $builder `,` $value   ( `,` $valid^ )? attr-dict";
 }
 
+def Arrow_AppendNullOp : Arrow_Op<"array_builder.append_null"> {
+    let summary = "Appends a null value to an Arrow array builder.";
+    let arguments = (ins Arrow_ArrayBuilder:$builder);
+    let assemblyFormat = " $builder attr-dict";
+}
+
 def Arrow_BuilderFromPtr : Arrow_Op<"array_builder.from_ptr", [Pure] > {
     let summary = "Creates a builder value from a pointer to an ArrowColumn builder that is managed in the runtime";
     let arguments = (ins RefType:$ptr);

--- a/include/lingodb/runtime/ArrowColumn.h
+++ b/include/lingodb/runtime/ArrowColumn.h
@@ -28,6 +28,7 @@ class ArrowColumnBuilder {
    ArrowColumnBuilder* getChildBuilder();
    void addBool(bool isValid, bool value);
    void addFixedSized(bool isValid, uint8_t* value);
+   void addNull();
 
    void addList(bool isValid);
    void addBinary(bool isValid, runtime::VarLen32);

--- a/src/compiler/Conversion/ArrowToStd/ArrowToStd.cpp
+++ b/src/compiler/Conversion/ArrowToStd/ArrowToStd.cpp
@@ -243,6 +243,15 @@ class BuilderAppendVariableSizeBinaryLowering : public OpConversionPattern<arrow
       return success();
    }
 };
+class BuilderAppendNullLowering : public OpConversionPattern<arrow::AppendNullOp> {
+   public:
+   using OpConversionPattern<arrow::AppendNullOp>::OpConversionPattern;
+   LogicalResult matchAndRewrite(arrow::AppendNullOp op, OpAdaptor adaptor, ConversionPatternRewriter& rewriter) const override {
+      rt::ArrowColumnBuilder::addNull(rewriter, op.getLoc())({adaptor.getBuilder()});
+      rewriter.eraseOp(op);
+      return success();
+   }
+};
 
 } // end anonymous namespace
 template <class Op>
@@ -341,6 +350,7 @@ void ArrowToStdLoweringPass::runOnOperation() {
    patterns.insert<BuilderAppendFixedSizedLowering>(typeConverter, &getContext());
    patterns.insert<BuilderAppendBoolLowering>(typeConverter, &getContext());
    patterns.insert<BuilderAppendVariableSizeBinaryLowering>(typeConverter, &getContext());
+   patterns.insert<BuilderAppendNullLowering>(typeConverter, &getContext());
    if (failed(applyFullConversion(module, target, std::move(patterns))))
       signalPassFailure();
 }

--- a/src/compiler/Conversion/DBToStd/LowerToStd.cpp
+++ b/src/compiler/Conversion/DBToStd/LowerToStd.cpp
@@ -226,7 +226,9 @@ class AppendArrowLowering : public OpConversionPattern<db::AppendArrowOp> {
          valid = rewriter.create<arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::eq, unpacked.first, falseValue);
       }
       //todo: also support more base types here
-      if (baseType.isIndex()) {
+      if (mlir::isa<mlir::NoneType>(baseType)) {
+         rewriter.create<lingodb::compiler::dialect::arrow::AppendNullOp>(loc, builder);
+      } else if (baseType.isIndex()) {
          rewriter.create<lingodb::compiler::dialect::arrow::AppendFixedSizedOp>(loc, builder, value, valid); //todo: necessary?
       } else if (baseType.isInteger(1)) {
          rewriter.create<lingodb::compiler::dialect::arrow::AppendBoolOp>(loc, builder, value, valid);

--- a/src/compiler/Conversion/SubOpToControlFlow/SubOpToControlFlow.cpp
+++ b/src/compiler/Conversion/SubOpToControlFlow/SubOpToControlFlow.cpp
@@ -1268,7 +1268,9 @@ class CreateFromResultTableLowering : public SubOpConversionPattern<subop::Creat
 };
 class CreateTableLowering : public SubOpConversionPattern<subop::GenericCreateOp> {
    std::string arrowDescrFromType(mlir::Type type) const {
-      if (type.isIndex()) {
+      if (mlir::isa<mlir::NoneType>(type)) {
+         return "null";
+      } else if (type.isIndex()) {
          return "int[64]";
       } else if (isIntegerType(type, 1)) {
          return "bool";

--- a/src/runtime/ArrowColumn.cpp
+++ b/src/runtime/ArrowColumn.cpp
@@ -63,6 +63,8 @@ std::shared_ptr<arrow::DataType> createType(std::string name, uint32_t p1, uint3
       return arrow::decimal128(p1, p2);
    } else if (name == "bool") {
       return arrow::boolean();
+   } else if (name == "null") {
+      return arrow::null();
    }
    throw std::runtime_error("unknown type");
 }
@@ -159,6 +161,11 @@ void ArrowColumnBuilder::addFixedSized(bool isValid, uint8_t* value) {
    } else {
       handleStatus(typedBuilder->Append(value));
    }
+}
+
+void ArrowColumnBuilder::addNull() {
+   next();
+   handleStatus(builder->AppendNull());
 }
 
 void ArrowColumnBuilder::addBinary(bool isValid, lingodb::runtime::VarLen32 string) {

--- a/src/tools/sqlite-tester.cpp
+++ b/src/tools/sqlite-tester.cpp
@@ -57,10 +57,17 @@ struct ResultHasher : public execution::ResultProcessor {
       std::vector<bool> convertHex;
       std::vector<bool> isFloat;
       for (auto c : table->columns()) {
-         convertHex.push_back(table->schema()->field(positions.size())->type()->id() == arrow::Type::FIXED_SIZE_BINARY);
-         isFloat.push_back(table->schema()->field(positions.size())->type()->id() == arrow::Type::DOUBLE);
+         auto type = table->schema()->field(positions.size())->type()->id();
+         convertHex.push_back(type == arrow::Type::FIXED_SIZE_BINARY);
+         isFloat.push_back(type == arrow::Type::DOUBLE);
          std::stringstream sstr;
-         arrow::PrettyPrint(*c.get(), options, &sstr); //NOLINT (clang-diagnostic-unused-result)
+         if (type == arrow::Type::NA) {
+            for (int64_t i = 0; i < table->num_rows(); i++) {
+               sstr << "null\n";
+            }
+         } else {
+            arrow::PrettyPrint(*c.get(), options, &sstr); //NOLINT (clang-diagnostic-unused-result)
+         }
          columnReps.push_back(sstr.str());
          positions.push_back(0);
       }

--- a/test/sqlite-small/null.test
+++ b/test/sqlite-small/null.test
@@ -1,0 +1,5 @@
+query tsv
+SELECT NULL FROM (VALUES (1), (2)) AS t(value);
+----
+NULL
+NULL


### PR DESCRIPTION
## What changed

Adds a NULL Arrow column type and lowering path, so a query that materializes a NULL-only result column can execute. The SQL test formatter now expands Arrow's compact `NullArray` representation to one value per row.

## Root cause

Bare `NULL` has `!db.nullable<none>` type. The result materialization pipeline had neither an Arrow descriptor for `none` nor an append operation for it, leaving `db.arrow.append` illegal during lowering.

## Validation

- `cmake --build build/lingodb-debug -- -j1`
- `./build/lingodb-debug/sqlite-tester test/sqlite-small/null.test`
