### PR TITLE
Support INSERT from a query

### DIFF
--- a/src/compiler/frontend/sql_analyzer.cpp
+++ b/src/compiler/frontend/sql_analyzer.cpp
@@ -979,10 +979,8 @@ std::shared_ptr<ast::BoundInsertNode> SQLQueryAnalyzer::analyzeInsertNode(std::s
       error("Table " << insertNode->tableName << " does not exist", insertNode->loc);
    }
    auto boundTableProducer = analyzeTableProducer(insertNode->producer, context, resolverScope);
-   if (boundTableProducer->nodeType != ast::NodeType::QUERY_NODE || std::static_pointer_cast<ast::QueryNode>(boundTableProducer)->type != ast::QueryNodeType::BOUND_VALUES) {
-      error("Table producer type for insert node not yet supported", boundTableProducer->loc);
-   }
-   if (!std::static_pointer_cast<ast::BoundValuesQueryNode>(boundTableProducer)->modifiers.empty()) {
+   auto isBoundValues = boundTableProducer->nodeType == ast::NodeType::QUERY_NODE && std::static_pointer_cast<ast::QueryNode>(boundTableProducer)->type == ast::QueryNodeType::BOUND_VALUES;
+   if (isBoundValues && !std::static_pointer_cast<ast::BoundValuesQueryNode>(boundTableProducer)->modifiers.empty()) {
       error("Modifiers for insert node not yet supported", boundTableProducer->loc);
    }
    for (auto c : context->currentScope->targetInfo.getTargetColumns()) {
@@ -994,7 +992,6 @@ std::shared_ptr<ast::BoundInsertNode> SQLQueryAnalyzer::analyzeInsertNode(std::s
       }
    }
 
-   auto exprListTableRef = std::static_pointer_cast<ast::BoundValuesQueryNode>(boundTableProducer)->expressionListRef;
    auto rel = maybeRel.value();
    std::unordered_map<std::string, NullableType> allCollumnTypes;
    //Check for correct Type
@@ -1007,7 +1004,7 @@ std::shared_ptr<ast::BoundInsertNode> SQLQueryAnalyzer::analyzeInsertNode(std::s
       }
    }
 
-   return drv.nf.node<ast::BoundInsertNode>(insertNode->loc, insertNode->schema, insertNode->tableName, exprListTableRef, insertNode->columns, allCollumnTypes);
+   return drv.nf.node<ast::BoundInsertNode>(insertNode->loc, insertNode->schema, insertNode->tableName, boundTableProducer, insertNode->columns, allCollumnTypes);
 }
 std::shared_ptr<ast::SetNode> SQLQueryAnalyzer::analyzeSetNode(std::shared_ptr<ast::SetNode> setNode) {
    switch (setNode->setType) {

--- a/test/sqlite-small/insert-from-query.test
+++ b/test/sqlite-small/insert-from-query.test
@@ -1,0 +1,16 @@
+statement ok
+CREATE TABLE next(id INTEGER);
+
+statement ok
+CREATE TABLE seen(id INTEGER, level INTEGER);
+
+statement ok
+INSERT INTO next VALUES (1);
+
+statement ok
+INSERT INTO seen (id, level) SELECT id, 0 FROM next;
+
+query tsv
+SELECT id, level FROM seen;
+----
+1	0


### PR DESCRIPTION
## What changed

Allow `INSERT INTO ... SELECT ...` by retaining the bound query producer instead of requiring `VALUES`. Add a regression test covering an insert from a one-row table scan.

## Root cause

The analyser only accepted `BOUND_VALUES` producers, even though `BoundInsertNode` and its translation path already operate on a generic table producer.

## Validation

- `cmake --build build/lingodb-debug -- -j1`
- `./build/lingodb-debug/sqlite-tester test/sqlite-small/insert-from-query.test`
